### PR TITLE
Added flag to use cluster spark session

### DIFF
--- a/replay/session_handler.py
+++ b/replay/session_handler.py
@@ -24,6 +24,9 @@ def get_spark_session(
         70% of RAM by default.
     :param shuffle_partitions: number of partitions for Spark; triple CPU count by default
     """
+    if os.environ.get("SCRIPT_ENV", None) == "cluster":
+        return SparkSession.builder.getOrCreate()
+
     os.environ["PYSPARK_PYTHON"] = sys.executable
     os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
 


### PR DESCRIPTION
Providing spark session in `cluster` deploy mode. To use `get_spark_session` method in app submitted to YARN.