### PR TITLE
Fixing `DistributionNotFound` exception

### DIFF
--- a/replay/__init__.py
+++ b/replay/__init__.py
@@ -1,4 +1,7 @@
 """ RecSys library """
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("replay-rec").version
+try:
+    __version__ = pkg_resources.get_distribution("replay-rec").version
+except pkg_resources.DistributionNotFound:
+    __version__ = 'non-package'


### PR DESCRIPTION
Fixed `DistributionNotFound` exception when `replay` code used as a module. For example, when the `replay` is imported from a wheel file submitted on YARN.