### PR TITLE
Added `num_item_blocks` and `num_user_blocks` params to `ALSWrap`

### DIFF
--- a/replay/models/als.py
+++ b/replay/models/als.py
@@ -33,6 +33,12 @@ class ALSWrap(Recommender, ItemVectorModel):
         :param rank: hidden dimension for the approximate matrix
         :param implicit_prefs: flag to use implicit feedback
         :param seed: random seed
+        :param num_item_blocks: number of blocks the items will be partitioned into in order
+            to parallelize computation.
+            if None then will be init with number of partitions of log.
+        :param num_user_blocks: number of blocks the users will be partitioned into in order
+            to parallelize computation.
+            if None then will be init with number of partitions of log.
         """
         self.rank = rank
         self.implicit_prefs = implicit_prefs

--- a/replay/models/als.py
+++ b/replay/models/als.py
@@ -20,6 +20,7 @@ class ALSWrap(Recommender, ItemVectorModel):
         "rank": {"type": "loguniform_int", "args": [8, 256]},
     }
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         rank: int = 10,

--- a/replay/models/als.py
+++ b/replay/models/als.py
@@ -25,6 +25,8 @@ class ALSWrap(Recommender, ItemVectorModel):
         rank: int = 10,
         implicit_prefs: bool = True,
         seed: Optional[int] = None,
+        num_item_blocks: Optional[int] = None,
+        num_user_blocks: Optional[int] = None,
     ):
         """
         :param rank: hidden dimension for the approximate matrix
@@ -34,6 +36,8 @@ class ALSWrap(Recommender, ItemVectorModel):
         self.rank = rank
         self.implicit_prefs = implicit_prefs
         self._seed = seed
+        self._num_item_blocks = num_item_blocks
+        self._num_user_blocks = num_user_blocks
 
     @property
     def _init_args(self):
@@ -57,8 +61,15 @@ class ALSWrap(Recommender, ItemVectorModel):
         user_features: Optional[DataFrame] = None,
         item_features: Optional[DataFrame] = None,
     ) -> None:
+        if self._num_item_blocks is None:
+            self._num_item_blocks = log.rdd.getNumPartitions()
+        if self._num_user_blocks is None:
+            self._num_user_blocks = log.rdd.getNumPartitions()
+
         self.model = ALS(
             rank=self.rank,
+            numItemBlocks=self._num_item_blocks,
+            numUserBlocks=self._num_user_blocks,
             userCol="user_idx",
             itemCol="item_idx",
             ratingCol="relevance",


### PR DESCRIPTION
Identification of better settings (performance) for parameters of ALSWrap.

> numBlocks is the number of blocks the users and items will be partitioned into in order to parallelize computation
([link](https://spark.apache.org/docs/3.1.3/ml-collaborative-filtering.html))

Please try these settings if you don't know what value to set:
```bash
CORES_MAX=$(($EXECUTOR_CORES * $EXECUTOR_INSTANCES))
NUM_BLOCKS=$((3 * $CORES_MAX))
```

https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.ml.recommendation.ALS.html - additional info on blocked als