### PR TITLE
File dumping via spark methods [into `refactoring` branch]

### DIFF
--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -54,7 +54,7 @@ def save(model: BaseRecommender, path: str, overwrite: bool = False):
     df_path = join(path, "dataframes")
     for name, df in dataframes.items():
         if df is not None:
-            df.write.parquet(join(df_path, name))
+            df.write.mode("overwrite").parquet(join(df_path, name))
 
     if hasattr(model, "fit_users"):
         model.fit_users.write.mode("overwrite").parquet(join(df_path, "fit_users"))

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -3,8 +3,6 @@ import os
 import json
 import shutil
 from inspect import getfullargspec
-
-import joblib
 from os.path import exists, join
 
 import pyspark.sql.types as st
@@ -15,6 +13,7 @@ from replay.models import *
 from replay.models.base_rec import BaseRecommender
 from replay.session_handler import State
 from replay.splitters import *
+from replay.utils import save_picklable_to_parquet, load_pickled_from_parquet
 
 
 def prepare_dir(path):
@@ -26,7 +25,7 @@ def prepare_dir(path):
     os.makedirs(path)
 
 
-def save(model: BaseRecommender, path: str):
+def save(model: BaseRecommender, path: str, overwrite: bool = False):
     """
     Save fitted model to disk as a folder
 
@@ -34,26 +33,35 @@ def save(model: BaseRecommender, path: str):
     :param path: destination where model files will be stored
     :return:
     """
-    prepare_dir(path)
+    spark = State().session
+
+    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
+    if not overwrite:
+        is_exists = fs.exists(spark._jvm.org.apache.hadoop.fs.Path(path))
+        if is_exists:
+            raise FileExistsError(f"Path '{path}' already exists. Mode is 'overwrite = False'.")
+
+    fs.mkdirs(spark._jvm.org.apache.hadoop.fs.Path(join(path, "model")))
     model._save_model(join(path, "model"))
 
     init_args = model._init_args
     init_args["_model_name"] = str(model)
-    with open(join(path, "init_args.json"), "w") as json_file:
-        json.dump(init_args, json_file)
+    sc = spark.sparkContext
+    df = spark.read.json(sc.parallelize([json.dumps(init_args)]))
+    df.coalesce(1).write.mode("overwrite").json(join(path, "init_args.json"))
 
     dataframes = model._dataframes
     df_path = join(path, "dataframes")
-    os.makedirs(df_path)
     for name, df in dataframes.items():
-        df.write.parquet(join(df_path, name))
+        if df is not None:
+            df.write.parquet(join(df_path, name))
 
     if hasattr(model, "fit_users"):
-        model.fit_users.write.parquet(join(df_path, "fit_users"))
+        model.fit_users.write.mode("overwrite").parquet(join(df_path, "fit_users"))
     if hasattr(model, "fit_items"):
-        model.fit_items.write.parquet(join(df_path, "fit_items"))
+        model.fit_items.write.mode("overwrite").parquet(join(df_path, "fit_items"))
     if hasattr(model, "study"):
-        joblib.dump(model.study, join(path, "study"))
+        save_picklable_to_parquet(model.study, join(path, "study"))
 
 
 def load(path: str) -> BaseRecommender:
@@ -64,8 +72,7 @@ def load(path: str) -> BaseRecommender:
     :return: Restored trained model
     """
     spark = State().session
-    with open(join(path, "init_args.json"), "r") as json_file:
-        args = json.load(json_file)
+    args = spark.read.json(join(path, "init_args.json")).first().asDict(recursive=True)
     name = args["_model_name"]
     del args["_model_name"]
 
@@ -85,39 +92,46 @@ def load(path: str) -> BaseRecommender:
         model.arg = extra_args[arg]
 
     df_path = join(path, "dataframes")
-    dataframes = os.listdir(df_path)
-    for name in dataframes:
-        df = spark.read.parquet(join(df_path, name))
-        setattr(model, name, df)
+    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
+    statuses = fs.listStatus(spark._jvm.org.apache.hadoop.fs.Path(df_path))
+    dataframes_paths = [str(f.getPath()) for f in statuses]
+    for dataframe_path in dataframes_paths:
+        df = spark.read.parquet(dataframe_path)
+        attr_name = dataframe_path.split("/")[-1]
+        setattr(model, attr_name, df)
 
     model._load_model(join(path, "model"))
-    model.study = (
-        joblib.load(join(path, "study"))
-        if os.path.exists(join(path, "study"))
-        else None
-    )
+    model.study = load_pickled_from_parquet(join(path, "study"))
+
     return model
 
 
-def save_indexer(indexer: Indexer, path: str):
+def save_indexer(indexer: Indexer, path: str, overwrite: bool = False):
     """
     Save fitted indexer to disk as a folder
 
     :param indexer: Trained indexer
     :param path: destination where indexer files will be stored
     """
-    prepare_dir(path)
+    spark = State().session
+    
+    if not overwrite:
+        fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
+        is_exists = fs.exists(spark._jvm.org.apache.hadoop.fs.Path(path))
+        if is_exists:
+            raise FileExistsError(f"Path '{path}' already exists. Mode is 'overwrite = False'.")
 
     init_args = indexer._init_args
     init_args["user_type"] = str(indexer.user_type)
     init_args["item_type"] = str(indexer.item_type)
-    with open(join(path, "init_args.json"), "w") as json_file:
-        json.dump(init_args, json_file)
+    sc = spark.sparkContext
+    df = spark.read.json(sc.parallelize([json.dumps(init_args)]))
+    df.coalesce(1).write.mode("overwrite").json(join(path, "init_args.json"))
 
-    indexer.user_indexer.save(join(path, "user_indexer"))
-    indexer.item_indexer.save(join(path, "item_indexer"))
-    indexer.inv_user_indexer.save(join(path, "inv_user_indexer"))
-    indexer.inv_item_indexer.save(join(path, "inv_item_indexer"))
+    indexer.user_indexer.write().overwrite().save(join(path, "user_indexer"))
+    indexer.item_indexer.write().overwrite().save(join(path, "item_indexer"))
+    indexer.inv_user_indexer.write().overwrite().save(join(path, "inv_user_indexer"))
+    indexer.inv_item_indexer.write().overwrite().save(join(path, "inv_item_indexer"))
 
 
 def load_indexer(path: str) -> Indexer:
@@ -127,9 +141,8 @@ def load_indexer(path: str) -> Indexer:
     :param path: path to folder
     :return: restored Indexer
     """
-    State()
-    with open(join(path, "init_args.json"), "r") as json_file:
-        args = json.load(json_file)
+    spark = State().session
+    args = spark.read.json(join(path, "init_args.json")).first().asDict()
 
     user_type = args["user_type"]
     del args["user_type"]
@@ -153,18 +166,22 @@ def load_indexer(path: str) -> Indexer:
     return indexer
 
 
-def save_splitter(splitter: Splitter, path: str):
+def save_splitter(splitter: Splitter, path: str, overwrite: bool = False):
     """
     Save initialized splitter
 
     :param splitter: Initialized splitter
     :param path: destination where splitter files will be stored
     """
-    prepare_dir(path)
     init_args = splitter._init_args
     init_args["_splitter_name"] = str(splitter)
-    with open(join(path, "init_args.json"), "w") as json_file:
-        json.dump(init_args, json_file)
+    spark = State().session
+    sc = spark.sparkContext
+    df = spark.read.json(sc.parallelize([json.dumps(init_args)]))
+    if overwrite:
+        df.coalesce(1).write.mode("overwrite").json(join(path, "init_args.json"))
+    else:
+        df.coalesce(1).write.json(join(path, "init_args.json"))
 
 
 def load_splitter(path: str) -> Splitter:
@@ -174,9 +191,8 @@ def load_splitter(path: str) -> Splitter:
     :param path: path to folder
     :return: restored Splitter
     """
-    State()
-    with open(join(path, "init_args.json"), "r") as json_file:
-        args = json.load(json_file)
+    spark = State().session
+    args = spark.read.json(join(path, "init_args.json")).first().asDict()
     name = args["_splitter_name"]
     del args["_splitter_name"]
     splitter = globals()[name]

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -77,7 +77,9 @@ def save(
     init_args["_model_name"] = str(model)
     sc = spark.sparkContext
     df = spark.read.json(sc.parallelize([json.dumps(init_args)]))
-    df.coalesce(1).write.mode("overwrite").json(join(path, "init_args.json"))
+    df.coalesce(1).write.mode("overwrite").option(
+        "ignoreNullFields", "false"
+    ).json(join(path, "init_args.json"))
 
     dataframes = model._dataframes
     df_path = join(path, "dataframes")

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -7,6 +7,7 @@ from os.path import exists, join
 
 import pyspark.sql.types as st
 from pyspark.ml.feature import StringIndexerModel, IndexToString
+from pyspark.sql import SparkSession
 
 from replay.data_preparator import Indexer
 from replay.models import *
@@ -25,6 +26,23 @@ def prepare_dir(path):
     os.makedirs(path)
 
 
+def get_list_of_paths(spark: SparkSession, dir_path: str):
+    """Returns list of paths to files in the `dir_path`
+
+    Args:
+        spark: spark session
+        dir_path: path to dir in hdfs or local disk
+
+    Returns: list of paths to files
+
+    """
+    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(
+        spark._jsc.hadoopConfiguration()
+    )
+    statuses = fs.listStatus(spark._jvm.org.apache.hadoop.fs.Path(dir_path))
+    return [str(f.getPath()) for f in statuses]
+
+
 def save(model: BaseRecommender, path: str, overwrite: bool = False):
     """
     Save fitted model to disk as a folder
@@ -35,11 +53,15 @@ def save(model: BaseRecommender, path: str, overwrite: bool = False):
     """
     spark = State().session
 
-    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
+    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(
+        spark._jsc.hadoopConfiguration()
+    )
     if not overwrite:
         is_exists = fs.exists(spark._jvm.org.apache.hadoop.fs.Path(path))
         if is_exists:
-            raise FileExistsError(f"Path '{path}' already exists. Mode is 'overwrite = False'.")
+            raise FileExistsError(
+                f"Path '{path}' already exists. Mode is 'overwrite = False'."
+            )
 
     fs.mkdirs(spark._jvm.org.apache.hadoop.fs.Path(join(path, "model")))
     model._save_model(join(path, "model"))
@@ -57,9 +79,13 @@ def save(model: BaseRecommender, path: str, overwrite: bool = False):
             df.write.mode("overwrite").parquet(join(df_path, name))
 
     if hasattr(model, "fit_users"):
-        model.fit_users.write.mode("overwrite").parquet(join(df_path, "fit_users"))
+        model.fit_users.write.mode("overwrite").parquet(
+            join(df_path, "fit_users")
+        )
     if hasattr(model, "fit_items"):
-        model.fit_items.write.mode("overwrite").parquet(join(df_path, "fit_items"))
+        model.fit_items.write.mode("overwrite").parquet(
+            join(df_path, "fit_items")
+        )
     if hasattr(model, "study"):
         save_picklable_to_parquet(model.study, join(path, "study"))
 
@@ -72,7 +98,11 @@ def load(path: str) -> BaseRecommender:
     :return: Restored trained model
     """
     spark = State().session
-    args = spark.read.json(join(path, "init_args.json")).first().asDict(recursive=True)
+    args = (
+        spark.read.json(join(path, "init_args.json"))
+        .first()
+        .asDict(recursive=True)
+    )
     name = args["_model_name"]
     del args["_model_name"]
 
@@ -91,10 +121,7 @@ def load(path: str) -> BaseRecommender:
     for arg in extra_args:
         model.arg = extra_args[arg]
 
-    df_path = join(path, "dataframes")
-    fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
-    statuses = fs.listStatus(spark._jvm.org.apache.hadoop.fs.Path(df_path))
-    dataframes_paths = [str(f.getPath()) for f in statuses]
+    dataframes_paths = get_list_of_paths(spark, join(path, "dataframes"))
     for dataframe_path in dataframes_paths:
         df = spark.read.parquet(dataframe_path)
         attr_name = dataframe_path.split("/")[-1]
@@ -114,12 +141,16 @@ def save_indexer(indexer: Indexer, path: str, overwrite: bool = False):
     :param path: destination where indexer files will be stored
     """
     spark = State().session
-    
+
     if not overwrite:
-        fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(spark._jsc.hadoopConfiguration())
+        fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(
+            spark._jsc.hadoopConfiguration()
+        )
         is_exists = fs.exists(spark._jvm.org.apache.hadoop.fs.Path(path))
         if is_exists:
-            raise FileExistsError(f"Path '{path}' already exists. Mode is 'overwrite = False'.")
+            raise FileExistsError(
+                f"Path '{path}' already exists. Mode is 'overwrite = False'."
+            )
 
     init_args = indexer._init_args
     init_args["user_type"] = str(indexer.user_type)
@@ -130,8 +161,12 @@ def save_indexer(indexer: Indexer, path: str, overwrite: bool = False):
 
     indexer.user_indexer.write().overwrite().save(join(path, "user_indexer"))
     indexer.item_indexer.write().overwrite().save(join(path, "item_indexer"))
-    indexer.inv_user_indexer.write().overwrite().save(join(path, "inv_user_indexer"))
-    indexer.inv_item_indexer.write().overwrite().save(join(path, "inv_item_indexer"))
+    indexer.inv_user_indexer.write().overwrite().save(
+        join(path, "inv_user_indexer")
+    )
+    indexer.inv_item_indexer.write().overwrite().save(
+        join(path, "inv_item_indexer")
+    )
 
 
 def load_indexer(path: str) -> Indexer:
@@ -179,7 +214,9 @@ def save_splitter(splitter: Splitter, path: str, overwrite: bool = False):
     sc = spark.sparkContext
     df = spark.read.json(sc.parallelize([json.dumps(init_args)]))
     if overwrite:
-        df.coalesce(1).write.mode("overwrite").json(join(path, "init_args.json"))
+        df.coalesce(1).write.mode("overwrite").json(
+            join(path, "init_args.json")
+        )
     else:
         df.coalesce(1).write.json(join(path, "init_args.json"))
 

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -18,13 +18,11 @@ from replay.utils import save_picklable_to_parquet, load_pickled_from_parquet
 
 
 def get_fs(spark: SparkSession):
-    """Gets `org.apache.hadoop.fs.FileSystem` instance from JVM gateway
+    """
+    Gets `org.apache.hadoop.fs.FileSystem` instance from JVM gateway
 
-    Args:
-        spark: spark session
-
-    Returns:
-
+    :param spark: spark session
+    :return:
     """
     fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(
         spark._jsc.hadoopConfiguration()
@@ -33,14 +31,12 @@ def get_fs(spark: SparkSession):
 
 
 def get_list_of_paths(spark: SparkSession, dir_path: str):
-    """Returns list of paths to files in the `dir_path`
+    """
+    Returns list of paths to files in the `dir_path`
 
-    Args:
-        spark: spark session
-        dir_path: path to dir in hdfs or local disk
-
-    Returns: list of paths to files
-
+    :param spark: spark session
+    :param dir_path: path to dir in hdfs or local disk
+    :return: list of paths to files
     """
     fs = get_fs(spark)
     statuses = fs.listStatus(spark._jvm.org.apache.hadoop.fs.Path(dir_path))

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -1,9 +1,7 @@
 # pylint: disable=wildcard-import,invalid-name,unused-wildcard-import,unspecified-encoding
-import os
 import json
-import shutil
 from inspect import getfullargspec
-from os.path import exists, join
+from os.path import join
 from pathlib import Path
 from typing import Union
 
@@ -17,15 +15,6 @@ from replay.models.base_rec import BaseRecommender
 from replay.session_handler import State
 from replay.splitters import *
 from replay.utils import save_picklable_to_parquet, load_pickled_from_parquet
-
-
-def prepare_dir(path):
-    """
-    Create empty `path` dir
-    """
-    if exists(path):
-        shutil.rmtree(path)
-    os.makedirs(path)
 
 
 def get_fs(spark: SparkSession):
@@ -81,7 +70,6 @@ def save(
                 f"Path '{path}' already exists. Mode is 'overwrite = False'."
             )
 
-    fs.mkdirs(spark._jvm.org.apache.hadoop.fs.Path(join(path, "model")))
     model._save_model(join(path, "model"))
 
     init_args = model._init_args
@@ -158,7 +146,9 @@ def load(path: str) -> BaseRecommender:
     return model
 
 
-def save_indexer(indexer: Indexer, path: Union[str, Path], overwrite: bool = False):
+def save_indexer(
+    indexer: Indexer, path: Union[str, Path], overwrite: bool = False
+):
     """
     Save fitted indexer to disk as a folder
 
@@ -171,9 +161,7 @@ def save_indexer(indexer: Indexer, path: Union[str, Path], overwrite: bool = Fal
     spark = State().session
 
     if not overwrite:
-        fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(
-            spark._jsc.hadoopConfiguration()
-        )
+        fs = get_fs(spark)
         is_exists = fs.exists(spark._jvm.org.apache.hadoop.fs.Path(path))
         if is_exists:
             raise FileExistsError(

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -4,6 +4,8 @@ import json
 import shutil
 from inspect import getfullargspec
 from os.path import exists, join
+from pathlib import Path
+from typing import Union
 
 import pyspark.sql.types as st
 from pyspark.ml.feature import StringIndexerModel, IndexToString
@@ -43,7 +45,9 @@ def get_list_of_paths(spark: SparkSession, dir_path: str):
     return [str(f.getPath()) for f in statuses]
 
 
-def save(model: BaseRecommender, path: str, overwrite: bool = False):
+def save(
+    model: BaseRecommender, path: Union[str, Path], overwrite: bool = False
+):
     """
     Save fitted model to disk as a folder
 
@@ -51,6 +55,9 @@ def save(model: BaseRecommender, path: str, overwrite: bool = False):
     :param path: destination where model files will be stored
     :return:
     """
+    if isinstance(path, Path):
+        path = str(path)
+
     spark = State().session
 
     fs = spark._jvm.org.apache.hadoop.fs.FileSystem.get(

--- a/replay/model_handler.py
+++ b/replay/model_handler.py
@@ -70,6 +70,7 @@ def save(
                 f"Path '{path}' already exists. Mode is 'overwrite = False'."
             )
 
+    fs.mkdirs(spark._jvm.org.apache.hadoop.fs.Path(path))
     model._save_model(join(path, "model"))
 
     init_args = model._init_args

--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -1615,10 +1615,10 @@ class NonPersonalizedRecommender(Recommender, ABC):
         return {"item_popularity": self.item_popularity}
 
     def _save_model(self, path: str):
-        joblib.dump({"fill": self.fill}, join(path))
+        save_picklable_to_parquet(self.fill, join(path, "params.dump"))
 
     def _load_model(self, path: str):
-        self.fill = joblib.load(join(path))["fill"]
+        self.fill = load_pickled_from_parquet(join(path, "params.dump"))
 
     def _clear_cache(self):
         if hasattr(self, "item_popularity"):

--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -12,7 +12,6 @@ Base abstract classes:
     with popularity statistics
 """
 
-import joblib
 import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -53,7 +52,7 @@ from replay.utils import (
     get_top_k_recs,
     return_recs,
     vector_euclidean_distance_similarity,
-    vector_dot,
+    vector_dot, save_picklable_to_parquet, load_pickled_from_parquet,
 )
 
 

--- a/replay/models/implicit_wrap.py
+++ b/replay/models/implicit_wrap.py
@@ -1,11 +1,11 @@
+from os.path import join
 from typing import Optional
 
-import joblib
 import pandas as pd
 from pyspark.sql import DataFrame
 
 from replay.models.base_rec import Recommender
-from replay.utils import to_csr
+from replay.utils import to_csr, save_picklable_to_parquet, load_pickled_from_parquet
 from replay.constants import REC_SCHEMA
 
 
@@ -43,10 +43,10 @@ class ImplicitWrap(Recommender):
         return {"model": None}
 
     def _save_model(self, path: str):
-        joblib.dump(self.model, path)
+        save_picklable_to_parquet(self.model, join(path, "model"))
 
     def _load_model(self, path: str):
-        self.model = joblib.load(path)
+        self.model = load_pickled_from_parquet(join(path, "model"))
 
     def _fit(
         self,

--- a/replay/models/lightfm_wrap.py
+++ b/replay/models/lightfm_wrap.py
@@ -2,7 +2,6 @@ import os
 from os.path import join
 from typing import Optional, Tuple
 
-import joblib
 import numpy as np
 import pandas as pd
 import pyspark.sql.functions as sf
@@ -14,7 +13,7 @@ from sklearn.preprocessing import MinMaxScaler
 
 from replay.constants import REC_SCHEMA
 from replay.models.base_rec import HybridRecommender
-from replay.utils import to_csr, check_numeric
+from replay.utils import to_csr, check_numeric, save_picklable_to_parquet, load_pickled_from_parquet
 from replay.session_handler import State
 
 
@@ -55,15 +54,14 @@ class LightFMWrap(HybridRecommender):
         }
 
     def _save_model(self, path: str):
-        os.makedirs(path)
-        joblib.dump(self.model, join(path, "model"))
-        joblib.dump(self.user_feat_scaler, join(path, "user_feat_scaler"))
-        joblib.dump(self.item_feat_scaler, join(path, "item_feat_scaler"))
+        save_picklable_to_parquet(self.model, join(path, "model"))
+        save_picklable_to_parquet(self.user_feat_scaler, join(path, "user_feat_scaler"))
+        save_picklable_to_parquet(self.item_feat_scaler, join(path, "item_feat_scaler"))
 
     def _load_model(self, path: str):
-        self.model = joblib.load(join(path, "model"))
-        self.user_feat_scaler = joblib.load(join(path, "user_feat_scaler"))
-        self.item_feat_scaler = joblib.load(join(path, "item_feat_scaler"))
+        self.model = load_pickled_from_parquet(join(path, "model"))
+        self.user_feat_scaler = load_pickled_from_parquet(join(path, "user_feat_scaler"))
+        self.item_feat_scaler = load_pickled_from_parquet(join(path, "item_feat_scaler"))
 
     def _feature_table_to_csr(
         self,

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -1,3 +1,4 @@
+import pickle
 from typing import Any, Iterable, List, Optional, Set, Tuple, Union
 
 import collections
@@ -7,7 +8,7 @@ import pyspark.sql.types as st
 
 from numpy.random import default_rng
 from pyspark.ml.linalg import DenseVector, Vectors, VectorUDT
-from pyspark.sql import Column, DataFrame, Window, functions as sf
+from pyspark.sql import SparkSession, Column, DataFrame, Window, functions as sf
 from scipy.sparse import csr_matrix
 
 from replay.constants import AnyDataFrame, NumType, REC_SCHEMA
@@ -847,3 +848,36 @@ def return_recs(
 
     recs.write.parquet(path=recs_file_path, mode="overwrite")
     return None
+
+
+def save_picklable_to_parquet(obj: Any, path: str) -> None:
+    """
+    Function dumps object to disk or hdfs in parquet format.
+
+    Args:
+        obj: object to be saved
+        path: path to dump
+    """
+    sc = SparkSession.getActiveSession().sparkContext
+    # We can use `RDD.saveAsPickleFile`, but it has no "overwrite" parameter
+    pickled_instance = pickle.dumps(obj)
+    Record = collections.namedtuple("Record", ["data"])
+    rdd = sc.parallelize([Record(pickled_instance)])
+    instance_df = rdd.map(lambda rec: Record(bytearray(rec.data))).toDF()
+    instance_df.write.mode("overwrite").parquet(path)
+
+
+def load_pickled_from_parquet(path: str) -> Any:
+    """
+    Function loads object from disk or hdfs, what was dumped via `save_picklable_to_parquet` function.
+
+    Args:
+        path: source path
+
+    Returns: unpickled object
+
+    """
+    spark = SparkSession.getActiveSession()
+    df = spark.read.parquet(path)
+    pickled_instance = df.rdd.map(lambda row: bytes(row.data)).first()
+    return pickle.loads(pickled_instance)

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -858,7 +858,7 @@ def save_picklable_to_parquet(obj: Any, path: str) -> None:
         obj: object to be saved
         path: path to dump
     """
-    sc = SparkSession.getActiveSession().sparkContext
+    sc = State().session.sparkContext
     # We can use `RDD.saveAsPickleFile`, but it has no "overwrite" parameter
     pickled_instance = pickle.dumps(obj)
     Record = collections.namedtuple("Record", ["data"])
@@ -878,7 +878,7 @@ def load_pickled_from_parquet(path: str) -> Any:
     Returns: unpickled object
 
     """
-    spark = SparkSession.getActiveSession()
+    spark = State().session
     df = spark.read.parquet(path)
     pickled_instance = df.rdd.map(lambda row: bytes(row.data)).first()
     return pickle.loads(pickled_instance)

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -8,7 +8,7 @@ import pyspark.sql.types as st
 
 from numpy.random import default_rng
 from pyspark.ml.linalg import DenseVector, Vectors, VectorUDT
-from pyspark.sql import SparkSession, Column, DataFrame, Window, functions as sf
+from pyspark.sql import Column, DataFrame, Window, functions as sf
 from scipy.sparse import csr_matrix
 
 from replay.constants import AnyDataFrame, NumType, REC_SCHEMA

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -1,11 +1,10 @@
+import collections
 import pickle
 from typing import Any, Iterable, List, Optional, Set, Tuple, Union
 
-import collections
 import numpy as np
 import pandas as pd
 import pyspark.sql.types as st
-
 from numpy.random import default_rng
 from pyspark.ml.linalg import DenseVector, Vectors, VectorUDT
 from pyspark.sql import Column, DataFrame, Window, functions as sf
@@ -13,6 +12,7 @@ from scipy.sparse import csr_matrix
 
 from replay.constants import AnyDataFrame, NumType, REC_SCHEMA
 from replay.session_handler import State
+
 
 # pylint: disable=invalid-name
 
@@ -854,10 +854,11 @@ def save_picklable_to_parquet(obj: Any, path: str) -> None:
     """
     Function dumps object to disk or hdfs in parquet format.
 
-    Args:
-        obj: object to be saved
-        path: path to dump
+    :param obj: object to be saved
+    :param path: path to dump
+    :return:
     """
+
     sc = State().session.sparkContext
     # We can use `RDD.saveAsPickleFile`, but it has no "overwrite" parameter
     pickled_instance = pickle.dumps(obj)
@@ -872,11 +873,8 @@ def load_pickled_from_parquet(path: str) -> Any:
     Function loads object from disk or hdfs,
     what was dumped via `save_picklable_to_parquet` function.
 
-    Args:
-        path: source path
-
-    Returns: unpickled object
-
+    :param path: source path
+    :return: unpickled object
     """
     spark = State().session
     df = spark.read.parquet(path)

--- a/replay/utils.py
+++ b/replay/utils.py
@@ -869,7 +869,8 @@ def save_picklable_to_parquet(obj: Any, path: str) -> None:
 
 def load_pickled_from_parquet(path: str) -> Any:
     """
-    Function loads object from disk or hdfs, what was dumped via `save_picklable_to_parquet` function.
+    Function loads object from disk or hdfs,
+    what was dumped via `save_picklable_to_parquet` function.
 
     Args:
         path: source path


### PR DESCRIPTION
* `joblib.dump` can dump files only in non-distributed mode, i.e. it only executes on the driver and it can only write to the local disk. Therefore, it was replaced to Spark methods.
* added `save_picklable_to_parquet` and `load_pickled_from_parquet` methods.