### PR TITLE
`NonPersonalizedRecommender` predict optimization

### DIFF
--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -1694,14 +1694,17 @@ class NonPersonalizedRecommender(Recommender, ABC):
             ),
         )
 
-        max_hist_len = (
-            self._calc_max_hist_len(log, users)
-            if filter_seen_items and log is not None
-            else 0
-        )
+        if filter_seen_items and log is not None:
+            user_to_num_items = log.groupBy("user_idx").agg(
+                sf.countDistinct("item_idx").alias("num_items")
+            )
+            users = users.join(user_to_num_items, on="user_idx")
+            return users.join(
+                selected_item_popularity, on=(sf.col("rank") <= k + sf.col("num_items")), how="left"
+            )
 
         return users.crossJoin(
-            selected_item_popularity.filter(sf.col("rank") <= k + max_hist_len)
+            selected_item_popularity.filter(sf.col("rank") <= k)
         ).drop("rank")
 
     def _predict_with_sampling(


### PR DESCRIPTION
Reducing the number of model inference predictions.

The table shows how the infer time changes for `NonPersonalizedRecommender` models (`PopRec`, `Wilson` and `UCB`) when using this optimization.
![Screenshot from 2023-04-03 18-15-18](https://user-images.githubusercontent.com/5842832/230109029-9f440de2-cb05-43c9-a47b-f5e7618fba70.png)
