### PR TITLE
Refactor activations, normalizations, logits computation; add CE_restricted loss

### DIFF
--- a/replay/models/nn/sequential/bert4rec/lightning.py
+++ b/replay/models/nn/sequential/bert4rec/lightning.py
@@ -197,6 +197,8 @@ class Bert4Rec(lightning.LightningModule):
             loss_func = self._compute_loss_bce if self._loss_sample_count is None else self._compute_loss_bce_sampled
         elif self._loss_type == "CE":
             loss_func = self._compute_loss_ce if self._loss_sample_count is None else self._compute_loss_ce_sampled
+        elif self._loss_type == "CE_restricted":
+            loss_func = self._compute_loss_ce_restricted
         else:
             msg = f"Not supported loss type: {self._loss_type}"
             raise ValueError(msg)
@@ -316,6 +318,20 @@ class Bert4Rec(lightning.LightningModule):
         loss = self._loss(logits, labels_flat)
         return loss
 
+    def _compute_loss_ce_restricted(
+        self,
+        feature_tensors: TensorMap,
+        positive_labels: torch.LongTensor,
+        padding_mask: torch.BoolTensor,
+        tokens_mask: torch.BoolTensor,
+    ) -> torch.Tensor:
+        (logits, labels) = self._get_restricted_logits_for_ce_loss(
+                feature_tensors, positive_labels, padding_mask, tokens_mask
+            )
+
+        loss = self._loss(logits, labels)
+        return loss
+
     def _get_sampled_logits(
         self,
         feature_tensors: TensorMap,
@@ -398,11 +414,27 @@ class Bert4Rec(lightning.LightningModule):
             vocab_size,
         )
 
+    def _get_restricted_logits_for_ce_loss(
+        self,
+        feature_tensors: TensorMap,
+        positive_labels: torch.LongTensor,
+        padding_mask: torch.BoolTensor,
+        tokens_mask: torch.BoolTensor
+    ):
+        labels_mask = (~padding_mask) + tokens_mask
+        masked_tokens = ~labels_mask
+        positive_labels = cast(
+            torch.LongTensor, torch.masked_select(positive_labels, masked_tokens)
+        )  # (masked_batch_seq_size,)
+        output_emb = self._model.forward_step(feature_tensors, padding_mask, tokens_mask)[masked_tokens]
+        logits = self._model.get_logits_for_restricted_loss(output_emb)
+        return (logits, positive_labels)         
+
     def _create_loss(self) -> Union[torch.nn.BCEWithLogitsLoss, torch.nn.CrossEntropyLoss]:
         if self._loss_type == "BCE":
             return torch.nn.BCEWithLogitsLoss(reduction="sum")
 
-        if self._loss_type == "CE":
+        if self._loss_type == "CE"  or self._loss_type == "CE_restricted":
             return torch.nn.CrossEntropyLoss()
 
         msg = "Not supported loss_type"

--- a/replay/models/nn/sequential/bert4rec/model.py
+++ b/replay/models/nn/sequential/bert4rec/model.py
@@ -475,23 +475,6 @@ class ClassificationHead(BaseHead):
         :returns: Bias tensor.
         """
         return self.linear.bias
-    
-    # fused bias в линейном слое
-    def forward(
-        self,
-        out_embeddings: torch.Tensor,
-        item_ids: Optional[torch.LongTensor] = None,
-    ) -> torch.Tensor:
-        """
-        :param out_embeddings: Embeddings after `forward step`.
-        :param item_ids: Item ids to calculate scores.
-            Default: ``None``.
-
-        :returns: Calculated logits.
-        """
-        logits = torch.nn.functional.linear(out_embeddings, self.linear.weight, self.linear.bias)
-        return logits
-
 
 class TransformerBlock(torch.nn.Module):
     """

--- a/replay/models/nn/sequential/bert4rec/model.py
+++ b/replay/models/nn/sequential/bert4rec/model.py
@@ -392,7 +392,7 @@ class BaseHead(ABC, torch.nn.Module):
             item_embeddings = item_embeddings[item_ids]
             bias = bias[item_ids]
 
-        logits = torch.matmul(out_embeddings, item_embeddings.t()) + bias # torch matmul вместо squeeze (squeeze медленный на валидации в lighting в режиме FP16)
+        logits = torch.nn.functional.linear(out_embeddings, item_embeddings, bias) # torch.nn.functional.linear вместо squeeze (squeeze медленный на валидации в lighting в режиме FP16)
         return logits
         
     def forward_for_restricted_loss(

--- a/replay/models/nn/sequential/sasrec/model.py
+++ b/replay/models/nn/sequential/sasrec/model.py
@@ -298,7 +298,7 @@ class EmbeddingTyingHead(torch.nn.Module):
         if len(item_embeddings.shape) > 2:  # global_uniform, negative sharing=False, train only
             logits = (item_embeddings * out_embeddings.unsqueeze(-2)).sum(dim=-1)
         else:
-            logits = item_embeddings.matmul(out_embeddings.unsqueeze(-1)).squeeze(-1)
+            logits = torch.matmul(out_embeddings, item_embeddings.t()) # torch matmul вместо squeeze (squeeze медленный на валидации в lighting в режиме FP16)
         return logits
 
 


### PR DESCRIPTION
- Replaced manual `GELU` activation with `nn.GELU` module for consistency and performance improvements.
- Replaced `squeeze`-based logits computation with direct `matmul` for clarity and efficiency.
- Replaced manual `LayerNorm` implementation with `nn.LayerNorm` for consistency and performance improvements.
- Added `CE_restricted` function for restricted cross-entropy loss computation.

