### PR TITLE
Preserve tensor feature padding_value during serialization

### DIFF
--- a/docs/pages/padding_value_serialization_fix.md
+++ b/docs/pages/padding_value_serialization_fix.md
@@ -1,0 +1,28 @@
+# Preserve tensor feature padding values during serialization
+
+## Problem
+
+`TensorSchema._get_object_args()` serialized tensor feature metadata without including
+`TensorFeatureInfo.padding_value`. When a schema was restored, the constructor silently
+used its default padding value of `0`. Any custom value, such as `-1`, was therefore lost
+when saving and loading sequential datasets or sequence tokenizers.
+
+## Fix
+
+The serialized representation now includes `padding_value` for every tensor feature.
+`TensorSchema._create_object_by_args()` already passes serialized fields to
+`TensorFeatureInfo`, so no separate deserialization logic is required. Older saved data
+without this field remains compatible because `TensorFeatureInfo` defaults it to `0`.
+
+## Regression coverage
+
+The tests verify two levels of behavior:
+
+- A `TensorSchema` metadata round trip preserves a custom padding value.
+- Saving and loading sequential datasets preserves the padding value of every feature.
+
+Run the focused checks with:
+
+```bash
+pytest tests/data/nn/test_schema.py tests/data/nn/test_sequential_dataset.py
+```

--- a/replay/data/nn/schema.py
+++ b/replay/data/nn/schema.py
@@ -447,6 +447,7 @@ class TensorSchema(Mapping[str, TensorFeatureInfo]):
                 "cardinality": feature.cardinality if feature.is_cat else None,
                 "embedding_dim": feature.embedding_dim if feature.is_cat else None,
                 "tensor_dim": feature.tensor_dim if feature.is_num else None,
+                "padding_value": feature.padding_value,
             }
             for feature in self.all_features
         ]

--- a/tests/data/nn/test_schema.py
+++ b/tests/data/nn/test_schema.py
@@ -94,6 +94,23 @@ def test_tensor_feature_setters(some_num_tensor_feature, some_cat_tensor_feature
 
 
 @pytest.mark.torch
+def test_tensor_schema_serialization_preserves_padding_value():
+    schema = TensorSchema(
+        TensorFeatureInfo(
+            name="item_id",
+            feature_type=FeatureType.CATEGORICAL,
+            cardinality=10,
+            padding_value=-1,
+        )
+    )
+
+    serialized_schema = schema._get_object_args()
+    restored_schema = TensorSchema._create_object_by_args(serialized_schema)
+
+    assert restored_schema["item_id"].padding_value == -1
+
+
+@pytest.mark.torch
 def test_tensor_feature_invalid_init():
     with pytest.raises(ValueError) as exc1:
         TensorFeatureInfo(name="fake", feature_type="unavailable type")

--- a/tests/data/nn/test_sequential_dataset.py
+++ b/tests/data/nn/test_sequential_dataset.py
@@ -189,5 +189,10 @@ def test_save_and_load_sequential_dataset(dataset, request, tmp_path):
         sequential_dataset._tensor_schema._get_object_args()
         == loaded_sequential_dataset._tensor_schema._get_object_args()
     )
+    for feature_name in sequential_dataset._tensor_schema:
+        assert (
+            sequential_dataset._tensor_schema[feature_name].padding_value
+            == loaded_sequential_dataset._tensor_schema[feature_name].padding_value
+        )
     assert all(sequential_dataset._sequences.columns == loaded_sequential_dataset._sequences.columns)
     assert sequential_dataset._sequences.equals(loaded_sequential_dataset._sequences)


### PR DESCRIPTION
## Summary
This change ensures the `padding_value` of tensor features is included during schema serialization and restored when loading. This fixes losing custom padding values (e.g. `-1`) when saving and loading sequential datasets or tokenizers.

## Files changed
- schema.py — include `padding_value` in `_get_object_args` and ensure `_create_object_by_args` passes it to `TensorFeatureInfo`.
- padding_value_serialization_fix.md — describe the bug and fix.
- test_schema.py — add/verify `test_tensor_schema_serialization_preserves_padding_value`.
- test_sequential_dataset.py — verify save/load preserves feature padding values.

## Motivation
Previously custom padding values were not saved with tensor schema metadata and were reset to `0` on load. This breaks workflows relying on non-zero padding sentinels.

## Backward compatibility
Older saved metadata without `padding_value` remains compatible because `TensorFeatureInfo` defaults `padding_value` to `0`.

## Tests
```bash
pytest -q tests/data/nn/test_schema.py::test_tensor_schema_serialization_preserves_padding_value \
       tests/data/nn/test_sequential_dataset.py::test_save_and_load_sequential_dataset