### PR TITLE
Preserve inputs passed to AdaptiveTrimTransform

### DIFF
--- a/replay/nn/transform/trim.py
+++ b/replay/nn/transform/trim.py
@@ -83,7 +83,7 @@ class AdaptiveTrimTransform(torch.nn.Module):
         :param padding_mask_name: name of padding_mask in batch.
         """
         super().__init__()
-        self.feature_names = [feature_names] if isinstance(feature_names, str) else feature_names
+        self.feature_names = [feature_names] if isinstance(feature_names, str) else feature_names.copy()
         if padding_mask_name not in self.feature_names:
             self.feature_names.append(padding_mask_name)
 

--- a/tests/nn/transform/test_transform.py
+++ b/tests/nn/transform/test_transform.py
@@ -261,6 +261,7 @@ def test_adaptive_trim_transform(random_batch_with_fixed_padding_len):
     transform = AdaptiveTrimTransform(features_to_trim, padding_mask_name="item_id_mask")
     transformed_batch = transform(random_batch_with_fixed_padding_len)
 
+    assert features_to_trim == ["item_id", "cat_feature"]
     for feature in features_to_trim:
         assert transformed_batch[feature].shape[1] <= random_batch_with_fixed_padding_len[feature].shape[1]
 


### PR DESCRIPTION
## Summary

`AdaptiveTrimTransform` no longer mutates the list passed through `feature_names`.

## Why

The transform automatically adds `padding_mask_name` to its internal feature list. When the caller passed a list, the transform retained the same list object and appended the mask to it. Constructing a transform could therefore change configuration owned by the caller and affect later transforms that reused that list.

For example, after creating `AdaptiveTrimTransform(features, padding_mask_name="item_id_mask")`, a caller could unexpectedly observe `features == ["item_id", "cat_feature", "item_id_mask"]`.

## Implementation

The constructor makes a shallow copy of list inputs before adding the padding mask. String inputs and transform behavior are unchanged.

## Checks

- `poetry run ruff check replay/nn/transform/trim.py tests/nn/transform/test_transform.py`
- `poetry run ruff format --check replay/nn/transform/trim.py tests/nn/transform/test_transform.py`
- `poetry run pytest tests/nn/transform/test_transform.py -q` — 67 passed
