### PR TITLE
Handle ignored negatives in sampled losses

### DIFF
--- a/replay/nn/loss/base.py
+++ b/replay/nn/loss/base.py
@@ -40,6 +40,8 @@ class SampledLossOutput(TypedDict):
 class SampledLossBase(torch.nn.Module):
     """The base class for calculating sampled losses"""
 
+    negative_labels_ignore_index: int
+
     @property
     def logits_callback(
         self,
@@ -133,7 +135,11 @@ class SampledLossBase(torch.nn.Module):
         positive_logits = self.logits_callback(model_embeddings, positive_labels)
         assert positive_logits.size() == (masked_batch_size, 1)
 
-        negative_logits = self.logits_callback(model_embeddings, negative_labels)
+        negative_labels_for_lookup = negative_labels.masked_fill(
+            negative_labels == self.negative_labels_ignore_index,
+            0,
+        )
+        negative_logits = self.logits_callback(model_embeddings, negative_labels_for_lookup)
         assert negative_logits.size() == (masked_batch_size, num_negatives)
 
         if num_positives != 1:
@@ -181,8 +187,7 @@ def mask_negative_logits(
         where positive labels are equal to negative ones.
     """
 
-    if negative_labels_ignore_index >= 0:
-        negative_logits.masked_fill_(negative_labels == negative_labels_ignore_index, -1e9)
+    ignored_negatives = negative_labels == negative_labels_ignore_index
 
     if negative_labels.dim() > 1:
         # [masked_batch_size, num_negatives] -> [masked_batch_size, 1, num_negatives]
@@ -194,7 +199,7 @@ def mask_negative_logits(
 
     # [masked_batch_size, num_positives, num_negatives] -> [masked_batch_size, num_negatives]
     negative_mask = negative_mask.sum(-2).bool()
-    negative_logits.masked_fill_(negative_mask, -1e9)
+    negative_logits.masked_fill_(negative_mask | ignored_negatives, -torch.inf)
     return negative_logits
 
 

--- a/replay/nn/loss/bce.py
+++ b/replay/nn/loss/bce.py
@@ -187,6 +187,7 @@ class BCESampled(SampledLossBase):
         negative_logits = sampled["negative_logits"]  # [masked_batch_size, num_negatives]
         positive_labels = sampled["positive_labels"]  # [masked_batch_size, num_positives]
         negative_labels = sampled["negative_labels"]  # [masked_batch_size, num_negatives] or [num_negatives]
+        ignored_negatives = negative_labels == self.negative_labels_ignore_index
 
         # Reject negative samples matching target label & correct for remaining samples
         negative_logits = mask_negative_logits(
@@ -208,7 +209,8 @@ class BCESampled(SampledLossBase):
             torch.log((1 - negative_prob) + self.log_epsilon),
             -self.clamp_border,
             self.clamp_border,
-        ).sum()
+        )
+        negative_loss = negative_loss.masked_fill(ignored_negatives, 0).sum()
 
         loss = -(positive_loss + negative_loss)
         loss /= positive_logits.size(0)

--- a/replay/nn/loss/login_ce.py
+++ b/replay/nn/loss/login_ce.py
@@ -83,7 +83,11 @@ class LogInCEBase(SampledLossBase):
         positive_logits = self.logits_callback(model_embeddings, positive_labels)
         assert positive_logits.size() == (masked_batch_size, num_positives)
 
-        negative_logits = self.logits_callback(model_embeddings, negative_labels)
+        negative_labels_for_lookup = negative_labels.masked_fill(
+            negative_labels == self.negative_labels_ignore_index,
+            0,
+        )
+        negative_logits = self.logits_callback(model_embeddings, negative_labels_for_lookup)
         assert negative_logits.size() == (masked_batch_size, num_negatives)
 
         # [batch_size, seq_len, num_positives] -> [masked_batch_size, num_positives]

--- a/tests/nn/loss/test_loss.py
+++ b/tests/nn/loss/test_loss.py
@@ -135,6 +135,44 @@ def test_loss_forward_with_multiclass_negatives(loss, batch_name, request):
     loss(**batch)
 
 
+@pytest.mark.parametrize("loss", [CESampled(), BCESampled(), LogInCESampled()])
+def test_sampled_loss_ignores_padded_negatives(loss):
+    item_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]])
+
+    def get_logits(model_embeddings, item_ids):
+        selected_item_embeddings = item_embeddings[item_ids]
+        if item_ids.ndim == 1:
+            return model_embeddings @ selected_item_embeddings.T
+        return torch.einsum("bd,bnd->bn", model_embeddings, selected_item_embeddings)
+
+    loss.logits_callback = get_logits
+    batch = {
+        "feature_tensors": {},
+        "positive_labels": torch.tensor([[[0]]]),
+        "padding_mask": torch.tensor([[True]]),
+        "target_padding_mask": torch.tensor([[[True]]]),
+    }
+
+    embeddings_with_padding = torch.tensor([[[1.0, 0.0]]], requires_grad=True)
+    with_padding = loss(
+        model_embeddings=embeddings_with_padding,
+        negative_labels=torch.tensor([1, -100, 2]),
+        **batch,
+    )
+    with_padding.backward()
+
+    embeddings_without_padding = torch.tensor([[[1.0, 0.0]]], requires_grad=True)
+    without_padding = loss(
+        model_embeddings=embeddings_without_padding,
+        negative_labels=torch.tensor([1, 2]),
+        **batch,
+    )
+    without_padding.backward()
+
+    torch.testing.assert_close(with_padding, without_padding)
+    torch.testing.assert_close(embeddings_with_padding.grad, embeddings_without_padding.grad)
+
+
 def test_weighted_mean_clamps_zero_denominator():
     loss = torch.ones(2)
     sample_weight = torch.zeros_like(loss)

--- a/tests/nn/loss/test_loss.py
+++ b/tests/nn/loss/test_loss.py
@@ -135,8 +135,10 @@ def test_loss_forward_with_multiclass_negatives(loss, batch_name, request):
     loss(**batch)
 
 
-@pytest.mark.parametrize("loss", [CESampled(), BCESampled(), LogInCESampled()])
-def test_sampled_loss_ignores_padded_negatives(loss):
+@pytest.mark.parametrize("loss_class", [CESampled, BCESampled, LogInCESampled])
+@pytest.mark.parametrize("negative_labels_ignore_index", [-100, 0])
+def test_sampled_loss_ignores_padded_negatives(loss_class, negative_labels_ignore_index):
+    loss = loss_class(negative_labels_ignore_index=negative_labels_ignore_index)
     item_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]])
 
     def get_logits(model_embeddings, item_ids):
@@ -156,7 +158,7 @@ def test_sampled_loss_ignores_padded_negatives(loss):
     embeddings_with_padding = torch.tensor([[[1.0, 0.0]]], requires_grad=True)
     with_padding = loss(
         model_embeddings=embeddings_with_padding,
-        negative_labels=torch.tensor([1, -100, 2]),
+        negative_labels=torch.tensor([1, negative_labels_ignore_index, 2]),
         **batch,
     )
     with_padding.backward()


### PR DESCRIPTION
## Summary

Sampled CE, BCE, and LogInCE losses now handle padded negative labels consistently for both positive and negative `negative_labels_ignore_index` values.

## Problem

The losses documented `negative_labels_ignore_index=-100`, but the sentinel was still passed to the item embedding lookup. A normal `torch.nn.Embedding` lookup could therefore fail before the loss had a chance to mask the padded position. In addition, the shared mask only handled non-negative sentinel values, and BCE could retain a small numerical contribution from an ignored negative.

For example, a negative pool `[12, -100, 37]` attempted to look up item `-100`. The expected behavior is the same loss and gradients as the unpadded pool `[12, 37]`.

## Implementation

- Replace the sentinel with a valid item ID only for the embedding lookup.
- Keep the original labels for collision and padding masks.
- Mask ignored logits regardless of the sentinel sign.
- Remove ignored BCE terms exactly instead of relying on a near-zero sigmoid contribution.

The public constructors and defaults are unchanged. Inputs without ignored labels follow the same computation as before.

## Checks

- `poetry run ruff check replay/nn/loss/base.py replay/nn/loss/bce.py replay/nn/loss/login_ce.py tests/nn/loss/test_loss.py`
- `poetry run ruff format --check replay/nn/loss/base.py replay/nn/loss/bce.py replay/nn/loss/login_ce.py tests/nn/loss/test_loss.py`
- `poetry run pytest tests/nn/loss/test_loss.py -q` — 48 passed
- The regression test compares loss values and model gradients with and without padding for CESampled, BCESampled, and LogInCESampled, using both `-100` and `0` as the ignore index.
