### PR TITLE
Add memory-efficient sparse negative sampling

### DIFF
--- a/docs/pages/modules/redesigned_nn_models.rst
+++ b/docs/pages/modules/redesigned_nn_models.rst
@@ -345,6 +345,11 @@ _________________________________
 .. autoclass:: replay.nn.transform.UniformNegativeSamplingTransform
     :members: __init__
 
+SparseUniformNegativeSamplingTransform
+______________________________________
+.. autoclass:: replay.nn.transform.SparseUniformNegativeSamplingTransform
+    :members: __init__
+
 MultiClassNegativeSamplingTransform
 ____________________________________
 .. autoclass:: replay.nn.transform.MultiClassNegativeSamplingTransform

--- a/replay/nn/transform/__init__.py
+++ b/replay/nn/transform/__init__.py
@@ -1,7 +1,11 @@
 from .copy import CopyTransform
 from .equality_mask import EqualityMaskTransform
 from .grouping import GroupTransform
-from .negative_sampling import MultiClassNegativeSamplingTransform, UniformNegativeSamplingTransform
+from .negative_sampling import (
+    MultiClassNegativeSamplingTransform,
+    SparseUniformNegativeSamplingTransform,
+    UniformNegativeSamplingTransform,
+)
 from .next_token import NextTokenTransform
 from .rename import RenameTransform
 from .reshape import UnsqueezeTransform
@@ -20,6 +24,7 @@ __all__ = [
     "RenameTransform",
     "SelectTransform",
     "SequenceRollTransform",
+    "SparseUniformNegativeSamplingTransform",
     "TokenMaskTransform",
     "TrimTransform",
     "UniformNegativeSamplingTransform",

--- a/replay/nn/transform/negative_sampling.py
+++ b/replay/nn/transform/negative_sampling.py
@@ -1,6 +1,30 @@
 import torch
 
 
+def _validated_sample_distribution(
+    cardinality: int,
+    sample_distribution: torch.Tensor | None,
+) -> torch.Tensor:
+    if sample_distribution is None:
+        return torch.ones(cardinality)
+    if sample_distribution.ndim != 1:
+        msg = "sample_distribution must be a one-dimensional tensor."
+        raise ValueError(msg)
+    if sample_distribution.numel() != cardinality:
+        msg = (
+            "The sample_distribution parameter has an incorrect size. "
+            f"Got {sample_distribution.numel()}, expected {cardinality}."
+        )
+        raise ValueError(msg)
+    if not sample_distribution.is_floating_point():
+        msg = "sample_distribution must have a floating-point dtype."
+        raise TypeError(msg)
+    if not torch.isfinite(sample_distribution).all() or (sample_distribution < 0).any():
+        msg = "sample_distribution must contain finite non-negative weights."
+        raise ValueError(msg)
+    return sample_distribution
+
+
 class UniformNegativeSamplingTransform(torch.nn.Module):
     """
     Transform for global negative sampling.
@@ -76,6 +100,103 @@ class UniformNegativeSamplingTransform(torch.nn.Module):
         )
 
         output_batch[self.out_feature_name] = negatives
+        return output_batch
+
+
+class SparseUniformNegativeSamplingTransform(torch.nn.Module):
+    """
+    Sample unique negatives from items with positive sampling weights.
+
+    Unlike :class:`UniformNegativeSamplingTransform`, this transform stores and samples only
+    the positive-weight part of a sparse distribution. Sampled positions are mapped back to
+    catalog item IDs before they are added to the batch. A dense distribution uses the original
+    representation without an additional item mapping.
+    """
+
+    def __init__(
+        self,
+        cardinality: int,
+        num_negative_samples: int,
+        *,
+        out_feature_name: str | None = "negative_labels",
+        sample_distribution: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> None:
+        """
+        :param cardinality: number of unique items in the catalog, excluding padding.
+        :param num_negative_samples: number of unique negative item IDs to generate.
+        :param out_feature_name: name of the generated batch feature.
+        :param sample_distribution: one-dimensional, non-negative sampling weights for the
+            complete catalog. Zero-weight items are removed from the stored distribution.
+        :param generator: random number generator used for sampling.
+        """
+        if cardinality <= 0:
+            msg = "cardinality must be positive."
+            raise ValueError(msg)
+        if num_negative_samples <= 0:
+            msg = "num_negative_samples must be positive."
+            raise ValueError(msg)
+        if num_negative_samples >= cardinality:
+            msg = (
+                "The num_negative_samples parameter has an incorrect value. "
+                f"Got {num_negative_samples}, expected less than catalog cardinality ({cardinality})."
+            )
+            raise ValueError(msg)
+        sample_distribution = _validated_sample_distribution(cardinality, sample_distribution)
+
+        positive_weight_count = torch.count_nonzero(sample_distribution).item()
+        if positive_weight_count < num_negative_samples:
+            msg = (
+                "sample_distribution must contain at least "
+                f"{num_negative_samples} positive-weight candidates, got {positive_weight_count}"
+            )
+            raise ValueError(msg)
+
+        super().__init__()
+        self.out_feature_name = out_feature_name
+        self.num_negative_samples = num_negative_samples
+        self.generator = generator
+        if positive_weight_count == cardinality:
+            candidate_ids = None
+            compact_distribution = sample_distribution
+        else:
+            candidate_ids = torch.nonzero(sample_distribution > 0, as_tuple=True)[0]
+            compact_distribution = sample_distribution[candidate_ids].contiguous()
+        self.register_buffer("candidate_ids", candidate_ids)
+        self.register_buffer("sample_distribution", compact_distribution.detach())
+
+    def _validate_generator_device(self) -> None:
+        if self.generator is None:
+            return
+        generator_device = torch.device(self.generator.device)
+        distribution_device = self.sample_distribution.device
+        devices_are_compatible = generator_device.type == distribution_device.type and (
+            generator_device.type != "cuda"
+            or generator_device.index is None
+            or distribution_device.index is None
+            or generator_device.index == distribution_device.index
+        )
+        if not devices_are_compatible:
+            msg = (
+                "generator and sample_distribution must be on the same device; "
+                f"got {generator_device} and {distribution_device}. Replace generator after moving the transform."
+            )
+            raise RuntimeError(msg)
+
+    def forward(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Add a shared unique negative pool to a shallow batch copy."""
+        self._validate_generator_device()
+        compact_ids = torch.multinomial(
+            self.sample_distribution,
+            num_samples=self.num_negative_samples,
+            replacement=False,
+            generator=self.generator,
+        )
+
+        output_batch = dict(batch)
+        output_batch[self.out_feature_name] = (
+            compact_ids if self.candidate_ids is None else torch.take(self.candidate_ids, compact_ids)
+        )
         return output_batch
 
 

--- a/tests/nn/transform/test_sparse_negative_sampling.py
+++ b/tests/nn/transform/test_sparse_negative_sampling.py
@@ -1,0 +1,135 @@
+import pickle
+
+import pytest
+import torch
+
+from replay.nn.transform import SparseUniformNegativeSamplingTransform, UniformNegativeSamplingTransform
+
+
+def test_sparse_distribution_samples_only_positive_weight_items():
+    transform = SparseUniformNegativeSamplingTransform(
+        cardinality=10,
+        num_negative_samples=3,
+        sample_distribution=torch.tensor([0.0, 1.0, 0.0, 4.0, 0.0, 0.0, 2.0, 0.0, 3.0, 0.0]),
+        generator=torch.Generator().manual_seed(19),
+    )
+
+    output = transform({})
+
+    assert set(output["negative_labels"].tolist()).issubset({1, 3, 6, 8})
+    assert torch.unique(output["negative_labels"]).numel() == 3
+    torch.testing.assert_close(transform.candidate_ids, torch.tensor([1, 3, 6, 8]))
+    assert transform.sample_distribution.numel() == 4
+
+
+def test_sparse_transform_preserves_generator_stream():
+    compact_weights = torch.tensor([1.0, 4.0, 2.0, 3.0])
+    expected_generator = torch.Generator().manual_seed(777)
+    transform = SparseUniformNegativeSamplingTransform(
+        cardinality=10,
+        num_negative_samples=3,
+        sample_distribution=torch.tensor([0.0, 1.0, 0.0, 4.0, 0.0, 0.0, 2.0, 0.0, 3.0, 0.0]),
+        generator=torch.Generator().manual_seed(777),
+    )
+    candidate_ids = torch.tensor([1, 3, 6, 8])
+
+    for _ in range(2):
+        expected = torch.take(
+            candidate_ids,
+            torch.multinomial(compact_weights, 3, replacement=False, generator=expected_generator),
+        )
+        torch.testing.assert_close(transform({})["negative_labels"], expected)
+
+
+def test_sparse_transform_uses_dense_distribution_without_item_mapping():
+    weights = torch.arange(1, 21, dtype=torch.float32)
+    expected = UniformNegativeSamplingTransform(
+        cardinality=20,
+        num_negative_samples=7,
+        sample_distribution=weights.clone(),
+        generator=torch.Generator().manual_seed(777),
+    )
+    actual = SparseUniformNegativeSamplingTransform(
+        cardinality=20,
+        num_negative_samples=7,
+        sample_distribution=weights,
+        generator=torch.Generator().manual_seed(777),
+    )
+
+    assert actual.candidate_ids is None
+    assert actual.sample_distribution.data_ptr() == weights.data_ptr()
+    for _ in range(2):
+        torch.testing.assert_close(actual({})["negative_labels"], expected({})["negative_labels"])
+
+
+def test_sparse_transform_restores_checkpoint_and_generator_stream():
+    weights = torch.tensor([0.0, 1.0, 0.0, 2.0, 3.0])
+    transform = SparseUniformNegativeSamplingTransform(
+        cardinality=5,
+        num_negative_samples=2,
+        sample_distribution=weights,
+        generator=torch.Generator().manual_seed(7),
+    )
+    transform({})
+
+    restored = pickle.loads(pickle.dumps(transform))
+    restored.load_state_dict(transform.state_dict(), strict=True)
+
+    torch.testing.assert_close(restored({})["negative_labels"], transform({})["negative_labels"])
+    assert torch.equal(restored.generator.get_state(), transform.generator.get_state())
+
+
+def test_sparse_transform_detaches_compacted_weights():
+    weights = torch.tensor([0.0, 1.0, 0.0, 2.0], requires_grad=True)
+    transform = SparseUniformNegativeSamplingTransform(
+        cardinality=4,
+        num_negative_samples=2,
+        sample_distribution=weights,
+    )
+
+    assert not transform.sample_distribution.requires_grad
+    assert transform.sample_distribution.grad_fn is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"cardinality": 0, "num_negative_samples": 1}, "cardinality must be positive"),
+        ({"cardinality": 4, "num_negative_samples": 0}, "num_negative_samples must be positive"),
+        (
+            {"cardinality": 4, "num_negative_samples": 2, "sample_distribution": torch.ones(3)},
+            "incorrect size",
+        ),
+        ({"cardinality": 4, "num_negative_samples": 4}, "less than catalog cardinality"),
+        (
+            {
+                "cardinality": 4,
+                "num_negative_samples": 2,
+                "sample_distribution": torch.tensor([1.0, 0.0, 0.0, 0.0]),
+            },
+            "positive-weight candidates",
+        ),
+    ],
+)
+def test_sparse_transform_rejects_invalid_sampling_contract(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        SparseUniformNegativeSamplingTransform(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("sample_distribution", "error", "message"),
+    [
+        (torch.ones((1, 4)), ValueError, "one-dimensional"),
+        (torch.ones(4, dtype=torch.long), TypeError, "floating-point"),
+        (torch.tensor([1.0, -1.0, 2.0, 3.0]), ValueError, "finite non-negative"),
+        (torch.tensor([1.0, float("nan"), 2.0, 3.0]), ValueError, "finite non-negative"),
+        (torch.tensor([1.0, float("inf"), 2.0, 3.0]), ValueError, "finite non-negative"),
+    ],
+)
+def test_sparse_transform_rejects_invalid_distribution(sample_distribution, error, message):
+    with pytest.raises(error, match=message):
+        SparseUniformNegativeSamplingTransform(
+            cardinality=4,
+            num_negative_samples=2,
+            sample_distribution=sample_distribution,
+        )


### PR DESCRIPTION
## Summary

Add `SparseUniformNegativeSamplingTransform`, an opt-in negative sampler that stores and samples only items with positive weights while returning original catalog item IDs.

## Why

`UniformNegativeSamplingTransform` passes the complete weight vector to `torch.multinomial`. This is appropriate for dense distributions, but it repeatedly scans zero-weight entries when only a small part of a large catalog is eligible.

For a catalog of 1,000,000 items where 10,000 items have positive weights, the existing transform stores and processes 1,000,000 weights on every call. The new transform stores 10,000 weights plus 10,000 catalog IDs, samples from that compact representation, and maps the result back to the original IDs.

This differs from #88: it does not introduce an adaptive sampling policy or change weights over time. It preserves the supplied weighted distribution and only removes entries that can never be sampled.

## Usage

```python
from replay.nn.transform import SparseUniformNegativeSamplingTransform

transform = SparseUniformNegativeSamplingTransform(
    cardinality=1_000_000,
    num_negative_samples=1024,
    sample_distribution=item_weights,
)
batch = transform(batch)
```

The existing `UniformNegativeSamplingTransform` remains unchanged. Dense input uses a direct fallback without an extra item-ID mapping.

## Benchmark

Measured locally on CPU with PyTorch 2.11.0. The workload used a catalog cardinality of 1,000,000, 10,000 positive weights, and 1,024 unique samples per call. Results are medians of 10 calls after 3 warm-up calls:

| Transform | Median per call | Stored tensor state |
|---|---:|---:|
| `UniformNegativeSamplingTransform` | 27.246 ms | 4,000,000 bytes |
| `SparseUniformNegativeSamplingTransform` | 0.413 ms | 120,000 bytes |

In this sparse case, sampling was 66x faster and stored tensor state was reduced by 97%. The exact gain depends on catalog size and the proportion of positive weights; dense distributions use the original representation.

## Checks

- `poetry run ruff check replay/nn/transform/negative_sampling.py replay/nn/transform/__init__.py tests/nn/transform/test_sparse_negative_sampling.py`
- `poetry run ruff format --check replay/nn/transform/negative_sampling.py replay/nn/transform/__init__.py tests/nn/transform/test_sparse_negative_sampling.py`
- `poetry run pytest tests/nn/transform/test_sparse_negative_sampling.py tests/nn/transform/test_transform.py -q` — 82 passed
- `poetry run sphinx-build -b html docs docs/_build/html-review` — succeeded; the new class is present in the generated API reference
- Tests cover sparse and dense paths, deterministic generator state, serialization, detached weights, invalid distributions, and original catalog ID restoration.
