### PR TITLE
Correct metrics for candidate-subset inference

### DIFF
--- a/replay/nn/lightning/callback/metrics_callback.py
+++ b/replay/nn/lightning/callback/metrics_callback.py
@@ -68,6 +68,8 @@ class ComputeMetricsCallback(lightning.Callback):
         self._verbose = verbose
         self._validation_metrics: dict[int, dict[str, float]] = {}
         self._test_metrics: dict[int, dict[str, float]] = {}
+        self._candidates: torch.LongTensor | None = None
+        self._device_candidates: torch.LongTensor | None = None
 
     def get_metrics(
         self,
@@ -102,16 +104,57 @@ class ComputeMetricsCallback(lightning.Callback):
     def on_validation_epoch_start(
         self,
         trainer: lightning.Trainer,
-        pl_module: LightningModule,  # noqa: ARG002
+        pl_module: LightningModule,
     ) -> None:
+        self._set_candidates(pl_module)
         self._epoch_start(dataloaders_size=trainer.num_val_batches)
 
     def on_test_epoch_start(
         self,
         trainer: lightning.Trainer,
-        pl_module: LightningModule,  # noqa: ARG002
+        pl_module: LightningModule,
     ) -> None:
+        self._set_candidates(pl_module)
         self._epoch_start(dataloaders_size=trainer.num_test_batches)
+
+    def _set_candidates(self, pl_module: LightningModule) -> None:
+        candidates = getattr(pl_module, "candidates_to_score", None)
+        if candidates is not None:
+            if not isinstance(candidates, torch.Tensor):
+                msg = "Candidates must be a tensor or None."
+                raise TypeError(msg)
+            self._validate_candidates(candidates, allow_row_wise=False)
+        self._candidates = candidates
+        self._device_candidates = None
+        self._set_postprocessor_candidates(candidates)
+
+    def _validate_candidates(self, candidates: torch.Tensor, *, allow_row_wise: bool) -> None:
+        valid_dimensions = (1, 2) if allow_row_wise else (1,)
+        if candidates.ndim not in valid_dimensions:
+            msg = "Candidates must be a one-dimensional tensor."
+            if allow_row_wise:
+                msg = "Batch candidates must be a one- or two-dimensional tensor."
+            raise ValueError(msg)
+        if candidates.dtype != torch.long:
+            msg = "Candidates must have torch.long dtype."
+            raise TypeError(msg)
+        if candidates.shape[-1] == 0:
+            msg = "Candidates must be non-empty."
+            raise ValueError(msg)
+        if candidates.ndim == 1:
+            has_duplicates = torch.unique(candidates).numel() != candidates.numel()
+        else:
+            sorted_candidates = torch.sort(candidates, dim=1).values
+            has_duplicates = (sorted_candidates[:, 1:] == sorted_candidates[:, :-1]).any()
+        if has_duplicates:
+            msg = "The tensor of candidates to score must be unique."
+            raise ValueError(msg)
+        if (candidates < 0).any():
+            msg = "Candidate IDs must be non-negative."
+            raise ValueError(msg)
+        if self._item_count is not None and (candidates >= self._item_count).any():
+            msg = "Candidate IDs must be less than item_count."
+            raise ValueError(msg)
 
     def _epoch_start(self, dataloaders_size):
         self._dataloaders_size = dataloaders_size
@@ -125,6 +168,48 @@ class ComputeMetricsCallback(lightning.Callback):
         for postprocessor in self._postprocessors:
             logits = postprocessor.on_validation(batch, logits)
         return logits
+
+    def _prepare_candidates(self, batch: dict, scores: torch.Tensor) -> torch.LongTensor | None:
+        if "candidates_to_score" in batch and batch["candidates_to_score"] is not self._candidates:
+            candidates = batch["candidates_to_score"]
+            if candidates is None:
+                self._set_postprocessor_candidates(None)
+                return None
+            if not isinstance(candidates, torch.Tensor):
+                msg = "Batch candidates must be a tensor or None."
+                raise TypeError(msg)
+            self._validate_candidates(candidates, allow_row_wise=True)
+            if candidates.ndim == 2 and candidates.shape[0] != scores.shape[0]:
+                msg = "Row-wise candidates and logits must have the same batch size."
+                raise ValueError(msg)
+            candidates = candidates.to(scores.device)
+        elif self._candidates is None:
+            self._set_postprocessor_candidates(None)
+            return None
+        elif self._candidates.device == scores.device:
+            candidates = self._candidates
+        else:
+            if self._device_candidates is None or self._device_candidates.device != scores.device:
+                self._device_candidates = self._candidates.to(scores.device)
+            candidates = self._device_candidates
+
+        if candidates.shape[-1] != scores.shape[1]:
+            msg = "The number of candidates must match the logits width."
+            raise ValueError(msg)
+        self._set_postprocessor_candidates(candidates)
+        return candidates
+
+    def _set_postprocessor_candidates(self, candidates: torch.LongTensor | None) -> None:
+        for postprocessor in self._postprocessors:
+            if (
+                candidates is not None
+                and candidates.ndim == 2
+                and not getattr(postprocessor, "_supports_row_wise_candidates", False)
+            ):
+                msg = "Row-wise candidates require a postprocessor that supports per-row candidate catalogs."
+                raise ValueError(msg)
+            if getattr(postprocessor, "candidates", None) is not candidates:
+                postprocessor.candidates = candidates
 
     def on_validation_batch_end(
         self,
@@ -171,8 +256,18 @@ class ComputeMetricsCallback(lightning.Callback):
         batch_idx: int,
         dataloader_idx: int,
     ) -> None:
+        candidates = self._prepare_candidates(batch, outputs["logits"])
         seen_scores = self._apply_postproccesors(batch, outputs["logits"])
-        sampled_items = torch.topk(seen_scores, k=self._metrics_builders[dataloader_idx].max_k, dim=1).indices
+        max_k = self._metrics_builders[dataloader_idx].max_k
+        if max_k > seen_scores.shape[1]:
+            msg = "The largest k must not exceed the number of score columns."
+            raise ValueError(msg)
+        sampled_items = torch.topk(seen_scores, k=max_k, dim=1).indices
+        if candidates is not None:
+            if candidates.ndim == 1:
+                sampled_items = candidates[sampled_items]
+            else:
+                sampled_items = torch.gather(candidates, 1, sampled_items)
         self._metrics_builders[dataloader_idx].add_prediction(
             sampled_items, batch[self._ground_truth_column], batch.get(self._train_column)
         )

--- a/replay/nn/lightning/callback/metrics_callback.py
+++ b/replay/nn/lightning/callback/metrics_callback.py
@@ -29,6 +29,10 @@ class ComputeMetricsCallback(lightning.Callback):
     To calculate the ``coverage`` and ``novelty`` metrics, the batch must additionally contain the ``train_column`` key.
     The padding value of this tensor can be any, the main condition is that the padding value does not overlap
     with the existing item ID values. For example, these can be negative values.
+
+    When only selected candidates are scored, their global item IDs must be supplied through
+    ``LightningModule.candidates_to_score`` or the batch key ``candidates_to_score``. A one-dimensional
+    tensor is shared by the batch; a two-dimensional batch tensor provides candidates per row.
     """
 
     def __init__(

--- a/replay/nn/lightning/postprocessor/seen_items.py
+++ b/replay/nn/lightning/postprocessor/seen_items.py
@@ -4,6 +4,14 @@ from replay.data.nn import TensorMap
 
 from ._base import PostprocessorBase
 
+_INTEGER_DTYPES = {
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+}
+
 
 class SeenItemsFilter(PostprocessorBase):
     """
@@ -32,20 +40,40 @@ class SeenItemsFilter(PostprocessorBase):
         processed_logits =
         [[   -inf,    -inf,  0.3000], # user0
         [-0.1000,    -inf,    -inf]]  # user1
-
     """
 
-    def __init__(self, item_count: int, seen_items_column="seen_ids") -> None:
+    _supports_row_wise_candidates = True
+
+    def __init__(self, item_count: int, seen_items_column: str = "seen_ids") -> None:
         """
         :param item_count: A total number of items that the model knows about (``cardinality``).
             It is recommended to take this value from ``TensorSchema``. \n
-            Please note that values ​​outside the range [0, `item_count-1`] are filtered out (considered as padding).
-        :param seen_items_column: A name of the column in a batch that contains users’ interactions (seen item ids).
+            Please note that values outside the range [0, `item_count-1`] are filtered out (considered as padding).
+        :param seen_items_column: A name of the column in a batch that contains users' interactions (seen item IDs).
         """
+        if item_count <= 0:
+            msg = "item_count must be positive."
+            raise ValueError(msg)
         super().__init__()
         self.item_count = item_count
         self.seen_items_column = seen_items_column
-        self._candidates = None
+        self._candidates: torch.LongTensor | None = None
+        self._candidate_lookup: torch.LongTensor | None = None
+        self._candidate_lookup_device: torch.device | None = None
+
+    @property
+    def candidates(self) -> torch.LongTensor | None:
+        """Return global item IDs represented by score columns."""
+        return self._candidates
+
+    @candidates.setter
+    def candidates(self, candidates: torch.LongTensor | None = None) -> None:
+        """Set global item IDs represented by score columns."""
+        if candidates is not None:
+            self._validate_candidates(candidates)
+        self._candidates = candidates
+        self._candidate_lookup = None
+        self._candidate_lookup_device = None
 
     def on_validation(self, batch: dict, logits: torch.Tensor) -> torch.Tensor:
         return self._compute_scores(batch, logits.detach().clone())
@@ -53,31 +81,91 @@ class SeenItemsFilter(PostprocessorBase):
     def on_prediction(self, batch: dict, logits: torch.Tensor) -> torch.Tensor:
         return self._compute_scores(batch, logits.detach().clone())
 
-    def _compute_scores(
-        self,
-        batch: TensorMap,
-        logits: torch.Tensor,
-    ) -> torch.Tensor:
-        seen_ids_padded = batch[self.seen_items_column]
-        padding_mask = (seen_ids_padded < self.item_count) & (seen_ids_padded >= 0)
+    def _compute_scores(self, batch: TensorMap, logits: torch.Tensor) -> torch.Tensor:
+        seen_ids = self._validate_inputs(batch, logits).to(device=logits.device, dtype=torch.long)
+        valid_seen = (seen_ids >= 0) & (seen_ids < self.item_count)
 
-        batch_factors = torch.arange(0, logits.size(0), device=logits.device) * self.item_count
-        factored_ids = seen_ids_padded + batch_factors.unsqueeze(1)
-        seen_ids_flat = factored_ids[padding_mask]
-
-        if self._candidates is not None:
-            _logits = logits.new_full((logits.size(0), self.item_count), -torch.inf)
-            _logits[:, self._candidates] = torch.reshape(logits, _logits[:, self.candidates].shape)
-            logits = _logits
-
-        if logits.is_contiguous():
-            logits.view(-1)[seen_ids_flat] = -torch.inf
+        if self._candidates is None:
+            local_columns = seen_ids
+        elif self._candidates.ndim == 1:
+            lookup = self._get_candidate_lookup(logits.device)
+            local_columns = lookup[seen_ids.clamp(min=0, max=self.item_count - 1)]
+            valid_seen &= local_columns >= 0
         else:
-            flat_scores = logits.flatten()
-            flat_scores[seen_ids_flat] = -torch.inf
-            logits = flat_scores.reshape(logits.shape)
+            candidates = self._candidates.to(logits.device)
+            sorted_candidates, local_columns_by_rank = torch.sort(candidates, dim=1)
+            safe_seen = seen_ids.clamp(min=0, max=self.item_count - 1)
+            insertion_points = torch.searchsorted(sorted_candidates, safe_seen.contiguous())
+            bounded_points = insertion_points.clamp(max=candidates.shape[1] - 1)
+            valid_seen &= insertion_points < candidates.shape[1]
+            valid_seen &= torch.gather(sorted_candidates, 1, bounded_points) == safe_seen
+            local_columns = torch.gather(local_columns_by_rank, 1, bounded_points)
 
-        if self._candidates is not None:
-            logits = logits[:, self._candidates]
-
+        rows = torch.arange(logits.shape[0], device=logits.device).unsqueeze(1).expand_as(seen_ids)
+        logits[rows[valid_seen], local_columns[valid_seen]] = -torch.inf
         return logits
+
+    def _validate_inputs(self, batch: TensorMap, logits: torch.Tensor) -> torch.Tensor:
+        if logits.ndim != 2:
+            msg = "logits must be a rank-two tensor."
+            raise ValueError(msg)
+        if not logits.is_floating_point():
+            msg = "logits must have a floating-point dtype."
+            raise TypeError(msg)
+
+        seen_ids = batch[self.seen_items_column]
+        if not isinstance(seen_ids, torch.Tensor):
+            msg = f"batch[{self.seen_items_column!r}] must be a tensor."
+            raise TypeError(msg)
+        if seen_ids.dtype not in _INTEGER_DTYPES:
+            msg = f"batch[{self.seen_items_column!r}] must have an integer dtype."
+            raise TypeError(msg)
+        if seen_ids.ndim != 2:
+            msg = f"batch[{self.seen_items_column!r}] must be a rank-two tensor."
+            raise ValueError(msg)
+        if seen_ids.shape[0] != logits.shape[0]:
+            msg = "Seen items and logits must have the same batch size."
+            raise ValueError(msg)
+        if self._candidates is not None and self._candidates.ndim == 2 and self._candidates.shape[0] != logits.shape[0]:
+            msg = "Row-wise candidates and logits must have the same batch size."
+            raise ValueError(msg)
+        expected_width = self.item_count if self._candidates is None else self._candidates.shape[-1]
+        if logits.shape[1] != expected_width:
+            msg = "The logits width must match item_count or the number of candidates."
+            raise ValueError(msg)
+        return seen_ids
+
+    def _validate_candidates(self, candidates: torch.Tensor) -> None:
+        if candidates.ndim not in (1, 2):
+            msg = "Candidates must be a one- or two-dimensional tensor."
+            raise ValueError(msg)
+        if candidates.dtype != torch.long:
+            msg = "Candidates must have torch.long dtype."
+            raise TypeError(msg)
+        if candidates.shape[-1] == 0:
+            msg = "Candidates must be non-empty."
+            raise ValueError(msg)
+        if candidates.ndim == 1:
+            has_duplicates = torch.unique(candidates).numel() != candidates.numel()
+        else:
+            sorted_candidates = torch.sort(candidates, dim=1).values
+            has_duplicates = (sorted_candidates[:, 1:] == sorted_candidates[:, :-1]).any()
+        if has_duplicates:
+            msg = "The tensor of candidates to score must be unique."
+            raise ValueError(msg)
+        if ((candidates < 0) | (candidates >= self.item_count)).any():
+            msg = "Candidate IDs must be in the range [0, item_count)."
+            raise ValueError(msg)
+
+    def _get_candidate_lookup(self, device: torch.device) -> torch.LongTensor:
+        candidates = self._candidates
+        if candidates is None or candidates.ndim != 1:  # pragma: no cover
+            msg = "A shared candidate vector is required for a catalog lookup."
+            raise RuntimeError(msg)
+        if self._candidate_lookup_device != device:
+            candidates = candidates.to(device)
+            lookup = torch.full((self.item_count,), -1, dtype=torch.long, device=device)
+            lookup[candidates] = torch.arange(candidates.numel(), dtype=torch.long, device=device)
+            self._candidate_lookup = lookup
+            self._candidate_lookup_device = device
+        return self._candidate_lookup

--- a/tests/nn/lightning/callback/test_metrics_callback_candidates.py
+++ b/tests/nn/lightning/callback/test_metrics_callback_candidates.py
@@ -1,9 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import lightning as L
 import pytest
 import torch
+from torch.utils.data import DataLoader
 
+from replay.nn.lightning import LightningModule
 from replay.nn.lightning.callback import ComputeMetricsCallback
 from replay.nn.lightning.postprocessor import SeenItemsFilter
 
@@ -16,6 +19,13 @@ class _RecordingMetricsBuilder:
 
     def add_prediction(self, predictions, ground_truth, train=None):
         self.predictions.append(predictions)
+
+
+class _FixedCandidateModel(torch.nn.Module):
+    def forward(self, query_id, candidates_to_score=None):
+        assert candidates_to_score is not None
+        logits = torch.tensor([0.8, 0.9, 0.1], device=query_id.device)
+        return {"logits": logits.expand(query_id.shape[0], -1)}
 
 
 def _callback_with_builder(candidates=None, postprocessors=None):
@@ -78,6 +88,35 @@ def test_row_wise_candidates_are_mapped_and_seen_items_are_masked():
     )
 
     torch.testing.assert_close(builder.predictions[0], torch.tensor([[4, 3], [5, 0]]))
+
+
+@pytest.mark.torch
+def test_lightning_validation_maps_candidates_after_seen_item_filtering():
+    callback = ComputeMetricsCallback(
+        metrics=["recall"],
+        ks=[1],
+        item_count=8,
+        postprocessors=[SeenItemsFilter(item_count=8)],
+        verbose=False,
+    )
+    model = LightningModule(_FixedCandidateModel())
+    model.candidates_to_score = torch.tensor([4, 1, 3])
+    dataloader = DataLoader(
+        [{"query_id": torch.tensor(0), "ground_truth": torch.tensor([4]), "seen_ids": torch.tensor([1])}],
+        batch_size=1,
+    )
+    trainer = L.Trainer(
+        callbacks=[callback],
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+
+    trainer.validate(model, dataloaders=dataloader)
+
+    assert callback.get_metrics()[0]["recall@1"] == 1.0
 
 
 @pytest.mark.parametrize(

--- a/tests/nn/lightning/callback/test_metrics_callback_candidates.py
+++ b/tests/nn/lightning/callback/test_metrics_callback_candidates.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from replay.nn.lightning.callback import ComputeMetricsCallback
+from replay.nn.lightning.postprocessor import SeenItemsFilter
+
+
+class _RecordingMetricsBuilder:
+    max_k = 2
+
+    def __init__(self):
+        self.predictions = []
+
+    def add_prediction(self, predictions, ground_truth, train=None):
+        self.predictions.append(predictions)
+
+
+def _callback_with_builder(candidates=None, postprocessors=None):
+    callback = ComputeMetricsCallback(metrics=["recall"], ks=[2], item_count=8, postprocessors=postprocessors)
+    callback._set_candidates(SimpleNamespace(candidates_to_score=candidates))
+    builder = _RecordingMetricsBuilder()
+    callback._metrics_builders = [builder]
+    callback._dataloaders_size = [2]
+    return callback, builder
+
+
+def test_subset_topk_is_mapped_to_global_item_ids():
+    callback, builder = _callback_with_builder(torch.tensor([4, 1, 3]))
+
+    callback._batch_end(
+        trainer=Mock(),
+        pl_module=Mock(),
+        outputs={"logits": torch.tensor([[0.8, 0.9, 0.1], [0.2, 0.3, 0.7]])},
+        batch={"ground_truth": torch.tensor([[1], [3]])},
+        batch_idx=0,
+        dataloader_idx=0,
+    )
+
+    torch.testing.assert_close(builder.predictions[0], torch.tensor([[1, 4], [3, 1]]))
+
+
+def test_batch_candidates_override_module_candidates():
+    callback, builder = _callback_with_builder(torch.tensor([0, 1, 2]))
+
+    callback._batch_end(
+        trainer=Mock(),
+        pl_module=Mock(),
+        outputs={"logits": torch.tensor([[0.1, 0.9, 0.2]])},
+        batch={
+            "ground_truth": torch.tensor([[4]]),
+            "candidates_to_score": torch.tensor([1, 4, 3]),
+        },
+        batch_idx=0,
+        dataloader_idx=0,
+    )
+
+    torch.testing.assert_close(builder.predictions[0], torch.tensor([[4, 3]]))
+
+
+def test_row_wise_candidates_are_mapped_and_seen_items_are_masked():
+    postprocessor = SeenItemsFilter(item_count=8)
+    callback, builder = _callback_with_builder(postprocessors=[postprocessor])
+
+    callback._batch_end(
+        trainer=Mock(),
+        pl_module=Mock(),
+        outputs={"logits": torch.tensor([[0.8, 0.9, 0.1], [0.2, 0.3, 0.7]])},
+        batch={
+            "ground_truth": torch.tensor([[4], [5]]),
+            "seen_ids": torch.tensor([[1, 7], [2, -1]]),
+            "candidates_to_score": torch.tensor([[4, 1, 3], [0, 5, 2]]),
+        },
+        batch_idx=0,
+        dataloader_idx=0,
+    )
+
+    torch.testing.assert_close(builder.predictions[0], torch.tensor([[4, 3], [5, 0]]))
+
+
+@pytest.mark.parametrize(
+    "candidates",
+    [
+        torch.tensor([1, 1]),
+        torch.tensor([-1, 2]),
+        torch.tensor([1, 8]),
+        torch.tensor([1.0, 2.0]),
+    ],
+)
+def test_invalid_candidates_are_rejected(candidates):
+    callback = ComputeMetricsCallback(metrics=["recall"], ks=[1], item_count=8)
+
+    with pytest.raises((TypeError, ValueError)):
+        callback._set_candidates(SimpleNamespace(candidates_to_score=candidates))


### PR DESCRIPTION
## Summary

Make validation and test metrics correct when a model scores a candidate subset instead of the full catalog. The callback now maps local score columns back to global item IDs, and `SeenItemsFilter` masks histories directly in candidate-local scores.

## Problem

With `candidates_to_score=[101, 700, 9005]`, column 1 in the logits represents item 700. The metrics callback previously sent column number 1 to `TorchMetricsBuilder`, so ground truth item 700 could never match. `SeenItemsFilter` also expanded subset logits to `[batch_size, item_count]` before masking, which made candidate-subset validation consume memory proportional to the full catalog.

## Behavior

- A module-level one-dimensional candidate list is supported.
- A batch-level candidate list takes precedence over the module-level list.
- Batch candidates may be shared by the batch or supplied per row.
- Candidate IDs, shapes, ranges, dtypes, and duplicates are validated before metrics are updated.
- Local top-k columns are mapped back to global item IDs.
- Seen items are masked in candidate-local coordinates without allocating a full-catalog score matrix.
- Full-catalog validation keeps its previous behavior.

No model API changes are required. Existing `candidates_to_score` inputs now produce metrics in the correct item-ID space. The accepted candidate layouts are also documented in `ComputeMetricsCallback`.

## Benchmark

Measured locally on CPU with PyTorch 2.11.0 using 128 users, a catalog of 100,000 items, 5,000 candidates, and 200 history items per user. Results are medians of 10 calls after 2 warm-up calls:

| Seen-item filtering | Median per call | Largest score tensor |
|---|---:|---:|
| Full-catalog expansion | 4.129 ms | 51.2 MB |
| Candidate-local masking | 0.335 ms | 2.56 MB |

The candidate-local path was 12.3x faster and reduced the largest score tensor by 95% in this workload. It also keeps a 0.8 MB item-to-column lookup for the shared candidate list, so score tensor plus lookup remains about 93% smaller than the expanded score tensor.

## Checks

- `poetry run ruff check replay/nn/lightning/callback/metrics_callback.py replay/nn/lightning/postprocessor/seen_items.py tests/nn/lightning/callback/test_metrics_callback_candidates.py`
- `poetry run ruff format --check replay/nn/lightning/callback/metrics_callback.py replay/nn/lightning/postprocessor/seen_items.py tests/nn/lightning/callback/test_metrics_callback_candidates.py`
- `poetry run pytest tests/nn/lightning/callback/test_metrics_callback_candidates.py tests/nn/lightning/postprocessor/test_postprocessor.py -q` — 13 passed
- `poetry run pytest tests/nn/lightning/callback/test_callback.py -q -k validation_callbacks` — 8 passed
- The focused suite includes a real Lightning validation pass covering candidate injection, seen-item filtering, global item-ID mapping, top-k selection, and Recall calculation.
