### PR TITLE
Build the TwoTower item cache in bounded chunks

### DIFF
--- a/replay/nn/sequential/twotower/model.py
+++ b/replay/nn/sequential/twotower/model.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from typing import Protocol
 
@@ -13,6 +14,8 @@ from replay.nn.output import InferenceOutput, TrainOutput
 from replay.nn.utils import warning_is_not_none
 
 from .reader import FeaturesReaderProtocol
+
+logger = logging.getLogger(__name__)
 
 
 class EmbedderProto(Protocol):
@@ -140,6 +143,7 @@ class ItemTower(torch.nn.Module):
         embedder: EmbedderProto,
         embedding_aggregator: AggregatorProto,
         encoder: ItemEncoderProto,
+        cache_batch_size: int | None = None,
     ):
         """
         :param schema: a tensor schema object with meta information on features.
@@ -156,12 +160,18 @@ class ItemTower(torch.nn.Module):
         :param encoder: An object of a class that performs the logic of generating
             an item hidden embedding representation based for
             the features got from ``item_features_reader``.
+        :param cache_batch_size: maximum number of item rows encoded at once when the full
+            evaluation cache is first built. ``None`` encodes the complete catalog at once.
         """
+        if cache_batch_size is not None and cache_batch_size <= 0:
+            msg = f"cache_batch_size must be positive, got {cache_batch_size}."
+            raise ValueError(msg)
         super().__init__()
         self.embedder = embedder
         self.feature_names = item_features_reader.feature_names
         self.embedding_aggregator = embedding_aggregator
         self.encoder = encoder
+        self.cache_batch_size = cache_batch_size
 
         for feature_name in schema:
             if feature_name not in self.feature_names:
@@ -224,6 +234,7 @@ class ItemTower(torch.nn.Module):
         model.feature_names = list(item_features)
         model.embedding_aggregator = embedding_aggregator
         model.encoder = encoder
+        model.cache_batch_size = None
 
         for feature_name, feature_tensor in item_features.items():
             model.register_buffer(f"{cls.FEATURE_BUFFER_PREFIX}{feature_name}", feature_tensor, persistent=True)
@@ -292,6 +303,32 @@ class ItemTower(torch.nn.Module):
         feature_name = next(iter(self.feature_names))
         return self.get_feature_buffer(feature_name)
 
+    def _encode_item_rows(self, row_slice: slice) -> torch.Tensor:
+        feature_tensors = {
+            feature_name: self.get_feature_buffer(feature_name)[row_slice] for feature_name in self.feature_names
+        }
+        embeddings = self.embedder(feature_tensors, self.feature_names)
+        aggregated_embeddings = self.embedding_aggregator(embeddings)
+        hidden_state = self.encoder(feature_tensors=feature_tensors, input_embeddings=aggregated_embeddings)
+        assert aggregated_embeddings.size() == hidden_state.size()
+        return hidden_state
+
+    def _build_chunked_cache(self, item_count: int) -> torch.Tensor:
+        cache_batch_size = self.cache_batch_size
+        if cache_batch_size is None:  # pragma: no cover
+            msg = "cache_batch_size must be set before building a chunked cache."
+            raise RuntimeError(msg)
+        logger.info("Building the %s-item evaluation cache in chunks of %s", item_count, cache_batch_size)
+        first_end = min(cache_batch_size, item_count)
+        first_chunk = self._encode_item_rows(slice(0, first_end))
+        cache = first_chunk.new_empty((item_count, *first_chunk.shape[1:]))
+        cache[:first_end].copy_(first_chunk)
+        for start in range(first_end, item_count, cache_batch_size):
+            end = min(start + cache_batch_size, item_count)
+            cache[start:end].copy_(self._encode_item_rows(slice(start, end)))
+        self.cache = cache
+        return cache
+
     def forward(
         self,
         candidates_to_score: torch.LongTensor | None = None,
@@ -312,6 +349,11 @@ class ItemTower(torch.nn.Module):
             if candidates_to_score is None:
                 return self.cache
             return self.cache[candidates_to_score]
+
+        if not self.training and candidates_to_score is None and self.cache_batch_size is not None:
+            item_count = self._get_any_feature_buffer().shape[0]
+            if item_count > self.cache_batch_size:
+                return self._build_chunked_cache(item_count)
 
         if candidates_to_score is None:
             feature_tensors = {
@@ -357,6 +399,7 @@ class TwoTowerBody(torch.nn.Module):
         query_tower_output_normalization: NormalizerProto,
         item_encoder: ItemEncoderProto,
         item_features_reader: FeaturesReaderProtocol,
+        item_cache_batch_size: int | None = None,
     ):
         """
         :param schema: tensor schema object with metainformation about features.
@@ -386,6 +429,8 @@ class TwoTowerBody(torch.nn.Module):
             You can use :class:`replay.nn.sequential.twotower.FeaturesReader` as a standard class.\n
             But you can implement your own feature processing,
             just follow the :class:`replay.nn.sequential.twotower.FeaturesReaderProtocol` protocol.
+        :param item_cache_batch_size: maximum number of item rows encoded at once when the full
+            evaluation cache is first built. ``None`` encodes the complete catalog at once.
 
         """
         super().__init__()
@@ -410,6 +455,7 @@ class TwoTowerBody(torch.nn.Module):
             embedder,
             item_embedding_aggregator,
             item_encoder,
+            cache_batch_size=item_cache_batch_size,
         )
 
     def reset_parameters(self) -> None:
@@ -545,6 +591,7 @@ class TwoTower(torch.nn.Module):
         excluded_features: list[str] | None = None,
         categorical_list_feature_aggregation_method: str = "sum",
         hidden_dim: int | None = None,
+        item_cache_batch_size: int | None = None,
     ) -> "TwoTower":
         """
         A class method for fast creation of the TwoTower instance.\n
@@ -575,6 +622,8 @@ class TwoTower(torch.nn.Module):
             Default: ``"sum"``.
         :param hidden_dim: hidden layer dimension of feed-forward network. If ``None``, uses ``embedding_dim``.
             Defaults to ``None``.
+        :param item_cache_batch_size: maximum number of item rows encoded at once when the full
+            evaluation cache is first built. ``None`` encodes the complete catalog at once.
         :return: an instance of TwoTower class.
         """
         from replay.nn.agg import SumAggregator
@@ -624,6 +673,7 @@ class TwoTower(torch.nn.Module):
                 query_tower_output_normalization=torch.nn.LayerNorm(embedding_dim),
                 item_encoder=SwiGLUEncoder(embedding_dim=embedding_dim, hidden_dim=2 * embedding_dim),
                 item_features_reader=item_features_reader,
+                item_cache_batch_size=item_cache_batch_size,
             ),
             loss=CE(ignore_index=schema.item_id_features.item().padding_value),
             context_merger=None,

--- a/tests/nn/sequential/twotower/test_twotower-model.py
+++ b/tests/nn/sequential/twotower/test_twotower-model.py
@@ -9,7 +9,7 @@ from replay.nn.ffn import SwiGLUEncoder
 from replay.nn.mask import DefaultAttentionMask
 from replay.nn.output import InferenceOutput, TrainOutput
 from replay.nn.sequential import PositionAwareAggregator, SasRecTransformerLayer
-from replay.nn.sequential.twotower import ItemTower, TwoTowerBody
+from replay.nn.sequential.twotower import ItemTower, TwoTower, TwoTowerBody
 
 
 def test_query_tower_forward(twotower_model, sequential_sample):
@@ -29,6 +29,80 @@ def test_item_tower_forward(tensor_schema_with_equal_embedding_dims, twotower_mo
     else:
         num_items = tensor_schema_with_equal_embedding_dims["item_id"].cardinality
     assert output.shape == (num_items, tensor_schema_with_equal_embedding_dims["item_id"].embedding_dim)
+
+
+def test_item_tower_builds_equivalent_cache_in_chunks(create_twotower_model):
+    standard = create_twotower_model().body.item_tower
+    chunked = create_twotower_model().body.item_tower
+    chunked.cache_batch_size = 3
+    chunk_sizes = []
+    original_encoder_forward = chunked.encoder.forward
+
+    def recording_encoder_forward(*args, **kwargs):
+        chunk_sizes.append(kwargs["input_embeddings"].shape[0])
+        return original_encoder_forward(*args, **kwargs)
+
+    chunked.encoder.forward = recording_encoder_forward
+    chunked.load_state_dict(standard.state_dict(), strict=True)
+    standard.eval()
+    chunked.eval()
+
+    with torch.no_grad():
+        expected = standard()
+        actual = chunked()
+
+    torch.testing.assert_close(actual, expected)
+    assert max(chunk_sizes) <= 3
+    assert chunked() is actual
+
+
+def test_item_tower_chunking_does_not_change_training_or_candidate_scoring(create_twotower_model):
+    item_tower = create_twotower_model().body.item_tower
+    item_tower.cache_batch_size = 2
+    candidates = torch.tensor([0, 2, 4])
+
+    item_tower.eval()
+    candidate_embeddings = item_tower(candidates)
+    assert candidate_embeddings.requires_grad
+    assert item_tower.cache is None
+
+    item_tower.train()
+    training_embeddings = item_tower()
+    assert training_embeddings.requires_grad
+    assert item_tower.cache is None
+
+
+def test_twotower_from_params_exposes_item_cache_batch_size(
+    tensor_schema_with_equal_embedding_dims,
+    item_features_reader,
+):
+    model = TwoTower.from_params(
+        schema=tensor_schema_with_equal_embedding_dims,
+        item_features_reader=item_features_reader,
+        embedding_dim=tensor_schema_with_equal_embedding_dims["item_id"].embedding_dim,
+        num_heads=1,
+        item_cache_batch_size=3,
+    )
+
+    assert model.body.item_tower.cache_batch_size == 3
+
+
+@pytest.mark.parametrize("cache_batch_size", [0, -1])
+def test_item_tower_rejects_nonpositive_cache_batch_size(
+    tensor_schema_with_equal_embedding_dims,
+    item_features_reader,
+    twotower_model,
+    cache_batch_size,
+):
+    with pytest.raises(ValueError, match="cache_batch_size must be positive"):
+        ItemTower(
+            schema=tensor_schema_with_equal_embedding_dims,
+            item_features_reader=item_features_reader,
+            embedder=twotower_model.body.embedder,
+            embedding_aggregator=twotower_model.body.item_tower.embedding_aggregator,
+            encoder=twotower_model.body.item_tower.encoder,
+            cache_batch_size=cache_batch_size,
+        )
 
 
 def test_item_tower_from_checkpoint(create_twotower_model, tmp_path):


### PR DESCRIPTION
## Summary

Add opt-in chunked construction of the full-catalog TwoTower item cache. Set `item_cache_batch_size` on `TwoTowerBody` or `TwoTower.from_params`; the default remains the existing single-call behavior.

## Why

The first full-catalog evaluation currently sends every item through the item tower at once. The final cache must remain in memory, but intermediate embeddings and encoder activations also scale with the complete catalog and can exhaust GPU memory.

With `item_cache_batch_size=16_384`, the final cache keeps its original shape while temporary item-tower tensors are limited to 16,384 rows at a time.

## Usage

```python
model = TwoTower.from_params(
    schema=tensor_schema,
    item_features_reader=item_features_reader,
    item_cache_batch_size=16_384,
)
```

The same option is available directly on `TwoTowerBody` and `ItemTower`.

Chunking is used only when all of the following are true:

- the item tower is in evaluation mode;
- the full catalog is requested;
- the cache has not been built yet;
- the catalog is larger than `item_cache_batch_size`.

Training, explicit candidate scoring, checkpoint keys, and the final cache layout are unchanged. Manual evaluation should still use `torch.no_grad()` or `torch.inference_mode()`.

## GPU benchmark

The chunking algorithm was measured on one NVIDIA A100-SXM4-80GB with PyTorch 2.10.0 and CUDA 12.8. The controlled workload used 50,000 items, embedding dimension 32, a 2x internal expansion, and chunks of 512 rows. Three measured runs followed one warm-up run.

The measurement was collected before this upstream port, using the same preallocated-cache and chunked-encoding algorithm in a downstream package layout. The public branch is covered by output-equivalence and bounded-chunk tests, but this exact public commit has not been remeasured on A100.

| Cache construction | Peak incremental allocation | Temporary allocation above final cache | Median time |
|---|---:|---:|---:|
| Full catalog | 32.0 MB | 25.6 MB | 1.187 ms |
| 512-row chunks | 6.728 MB | 0.328 MB | 10.908 ms |

Chunking reduced peak incremental allocation by 78.98% and temporary allocation above the final cache by 98.72%. The trade-off was a 9.19x increase in one-time cache construction time. The final cache remained 6.4 MB in both modes; maximum absolute output difference was `4.77e-7`.

## Checks

- `poetry run ruff check replay/nn/sequential/twotower/model.py tests/nn/sequential/twotower/test_twotower-model.py`
- `poetry run ruff format --check replay/nn/sequential/twotower/model.py tests/nn/sequential/twotower/test_twotower-model.py`
- `poetry run pytest tests/nn/sequential/twotower/test_twotower-model.py -q` — 28 passed
- Tests cover output equivalence, bounded chunk size, cache reuse, strict checkpoint loading, unchanged training and candidate paths, invalid configuration, and the `TwoTower.from_params` option.
