### PR TITLE
Target-aware trimming for sequence training

### DIFF
--- a/docs/pages/modules/redesigned_nn_models.rst
+++ b/docs/pages/modules/redesigned_nn_models.rst
@@ -330,6 +330,11 @@ _____________________
 .. autoclass:: replay.nn.transform.AdaptiveTrimTransform
     :members: __init__
 
+TargetAwareAdaptiveTrimTransform
+________________________________
+.. autoclass:: replay.nn.transform.TargetAwareAdaptiveTrimTransform
+    :members: __init__
+
 SelectTransform
 ______________________
 .. autoclass:: replay.nn.transform.SelectTransform

--- a/replay/nn/transform/__init__.py
+++ b/replay/nn/transform/__init__.py
@@ -8,7 +8,7 @@ from .reshape import UnsqueezeTransform
 from .select import SelectTransform
 from .sequence_roll import SequenceRollTransform
 from .token_mask import TokenMaskTransform
-from .trim import AdaptiveTrimTransform, TrimTransform
+from .trim import AdaptiveTrimTransform, TargetAwareAdaptiveTrimTransform, TrimTransform
 
 __all__ = [
     "AdaptiveTrimTransform",
@@ -20,6 +20,7 @@ __all__ = [
     "RenameTransform",
     "SelectTransform",
     "SequenceRollTransform",
+    "TargetAwareAdaptiveTrimTransform",
     "TokenMaskTransform",
     "TrimTransform",
     "UniformNegativeSamplingTransform",

--- a/replay/nn/transform/trim.py
+++ b/replay/nn/transform/trim.py
@@ -143,6 +143,12 @@ class TargetAwareAdaptiveTrimTransform(torch.nn.Module):
         if padding_mask.shape != target_padding_mask.shape:
             msg = "Input and target padding masks must have equal shapes."
             raise ValueError(msg)
+        if padding_mask.dtype != torch.bool or target_padding_mask.dtype != torch.bool:
+            msg = "Input and target padding masks must have boolean dtype."
+            raise TypeError(msg)
+        if padding_mask.device != target_padding_mask.device:
+            msg = "Input and target padding masks must be on the same device."
+            raise ValueError(msg)
         for name in self.feature_names:
             if batch[name].shape[:2] != padding_mask.shape:
                 msg = f"Feature '{name}' must start with shape {tuple(padding_mask.shape)}."

--- a/replay/nn/transform/trim.py
+++ b/replay/nn/transform/trim.py
@@ -105,3 +105,60 @@ class AdaptiveTrimTransform(torch.nn.Module):
         for name in self.feature_names:
             output_batch[name] = output_batch[name][:, -max_non_padded_seqlen:, ...].contiguous()
         return output_batch
+
+
+class TargetAwareAdaptiveTrimTransform(torch.nn.Module):
+    """Trim left padding unused by both model inputs and next-token targets."""
+
+    def __init__(
+        self,
+        feature_names: list[str] | str,
+        padding_mask_name: str = "padding_mask",
+        target_padding_mask_name: str = "target_padding_mask",
+        min_sequence_elements: int = 32_768,
+    ) -> None:
+        """
+        :param feature_names: names of sequence features to trim.
+        :param padding_mask_name: name of the input padding mask.
+        :param target_padding_mask_name: name of the next-token target mask.
+        :param min_sequence_elements: minimum input-mask size required to run trimming.
+            Set to ``0`` to trim every batch.
+        """
+        super().__init__()
+        if min_sequence_elements < 0:
+            msg = "min_sequence_elements must be non-negative"
+            raise ValueError(msg)
+        names = [feature_names] if isinstance(feature_names, str) else list(feature_names)
+        self.feature_names = list(dict.fromkeys((*names, padding_mask_name, target_padding_mask_name)))
+        self.padding_mask_name = padding_mask_name
+        self.target_padding_mask_name = target_padding_mask_name
+        self.min_sequence_elements = min_sequence_elements
+
+    def forward(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        padding_mask = batch[self.padding_mask_name]
+        target_padding_mask = batch[self.target_padding_mask_name]
+        if padding_mask.ndim != 2 or target_padding_mask.ndim != 2:
+            msg = "Input and target padding masks must have shape [batch, sequence]."
+            raise ValueError(msg)
+        if padding_mask.shape != target_padding_mask.shape:
+            msg = "Input and target padding masks must have equal shapes."
+            raise ValueError(msg)
+        for name in self.feature_names:
+            if batch[name].shape[:2] != padding_mask.shape:
+                msg = f"Feature '{name}' must start with shape {tuple(padding_mask.shape)}."
+                raise ValueError(msg)
+
+        if padding_mask.numel() < self.min_sequence_elements:
+            return batch
+        active_columns = (padding_mask | target_padding_mask).any(dim=0)
+        active_indices = active_columns.nonzero(as_tuple=False)
+        if active_indices.numel() == 0:
+            return batch
+        trim_start = int(active_indices[0].item())
+        if trim_start == 0:
+            return batch
+
+        output_batch = dict(batch.items())
+        for name in self.feature_names:
+            output_batch[name] = output_batch[name][:, trim_start:, ...].contiguous()
+        return output_batch

--- a/tests/nn/transform/test_transform.py
+++ b/tests/nn/transform/test_transform.py
@@ -13,6 +13,7 @@ from replay.nn.transform import (
     RenameTransform,
     SelectTransform,
     SequenceRollTransform,
+    TargetAwareAdaptiveTrimTransform,
     TokenMaskTransform,
     TrimTransform,
     UniformNegativeSamplingTransform,
@@ -279,6 +280,44 @@ def test_adaptive_trim_transform_wrong_name(random_batch):
     transform = AdaptiveTrimTransform("item_id", padding_mask_name="wrong_name")
     with pytest.raises(KeyError):
         transform(random_batch)
+
+
+def test_target_aware_trim_keeps_shifted_target_position():
+    batch = {
+        "item_id": torch.tensor([[0, 0, 3, 4, 5]]),
+        "padding_mask": torch.tensor([[False, False, True, True, True]]),
+        "target_padding_mask": torch.tensor([[False, True, True, True, True]]),
+    }
+    transform = TargetAwareAdaptiveTrimTransform("item_id", min_sequence_elements=0)
+
+    output = transform(batch)
+
+    assert output["item_id"].tolist() == [[0, 3, 4, 5]]
+    assert output["target_padding_mask"].tolist() == [[True, True, True, True]]
+    assert batch["item_id"].shape == (1, 5)
+
+
+def test_target_aware_trim_skips_small_batch():
+    batch = {
+        "item_id": torch.tensor([[0, 0, 3]]),
+        "padding_mask": torch.tensor([[False, False, True]]),
+        "target_padding_mask": torch.tensor([[False, True, True]]),
+    }
+    transform = TargetAwareAdaptiveTrimTransform("item_id", min_sequence_elements=4)
+
+    assert transform(batch) is batch
+
+
+def test_target_aware_trim_rejects_mismatched_masks():
+    batch = {
+        "item_id": torch.tensor([[0, 3, 4]]),
+        "padding_mask": torch.tensor([[False, True, True]]),
+        "target_padding_mask": torch.tensor([[True, True]]),
+    }
+    transform = TargetAwareAdaptiveTrimTransform("item_id", min_sequence_elements=0)
+
+    with pytest.raises(ValueError, match="equal shapes"):
+        transform(batch)
 
 
 def test_select_transform(random_batch):

--- a/tests/nn/transform/test_transform.py
+++ b/tests/nn/transform/test_transform.py
@@ -320,6 +320,18 @@ def test_target_aware_trim_rejects_mismatched_masks():
         transform(batch)
 
 
+def test_target_aware_trim_rejects_non_boolean_masks():
+    batch = {
+        "item_id": torch.tensor([[0, 3, 4]]),
+        "padding_mask": torch.tensor([[0, 1, 1]]),
+        "target_padding_mask": torch.tensor([[False, True, True]]),
+    }
+    transform = TargetAwareAdaptiveTrimTransform("item_id", min_sequence_elements=0)
+
+    with pytest.raises(TypeError, match="boolean dtype"):
+        transform(batch)
+
+
 def test_select_transform(random_batch):
     features = ["item_id", ("cat_feature",)]
     transform = SelectTransform(features)


### PR DESCRIPTION
## Summary

Adds an opt-in training transform that removes batch-wide left padding while
preserving every position used either by the query encoder or by the shifted
next-token target.

`AdaptiveTrimTransform` is sufficient for inference, where only the input mask
matters. During next-token training the target mask can start one position
earlier. Trimming by the input mask alone would therefore remove a valid loss
position. `TargetAwareAdaptiveTrimTransform` uses the union of both masks.

## Example

For a physical batch with sequence length 200, suppose the earliest valid input
starts at column 121, while the shifted target starts at column 120. The new
transform removes columns 0–119 and sends a sequence of length 80 to the model.
It does not remove column 120 merely because the input mask is false there.

For attention with quadratic sequence complexity, reducing the width from 200
to 80 reduces the corresponding score matrix to 16% of its original size. The
actual gain depends on the length distribution in each batch. Small batches can
bypass the extra scan through `min_sequence_elements`.

## Usage

```python
transform = TargetAwareAdaptiveTrimTransform(
    feature_names=["item_id", "timestamp", "positive_labels"],
    padding_mask_name="padding_mask",
    target_padding_mask_name="target_padding_mask",
)
```

The transform is opt-in and does not mutate the input mapping. Existing
transforms and defaults are unchanged.

## Validation

- full transform suite: 71 tests passed;
- tests cover shifted targets, bypass paths, shape and dtype validation, and
  input immutability;
- Ruff checks for the affected files and `git diff --check` passed.
