### PR TITLE
Length-bucketed query encoding

### DIFF
--- a/docs/pages/modules/redesigned_nn_models.rst
+++ b/docs/pages/modules/redesigned_nn_models.rst
@@ -72,6 +72,12 @@ QueryTower
 .. autoclass:: replay.nn.sequential.QueryTower
    :members: __init__, forward
 
+LengthBucketedQueryEncoder
+``````````````````````````````
+
+.. autoclass:: replay.nn.sequential.LengthBucketedQueryEncoder
+   :members: __init__, forward
+
 ItemTower
 ``````````````````````````````
 

--- a/replay/nn/sequential/__init__.py
+++ b/replay/nn/sequential/__init__.py
@@ -1,3 +1,4 @@
+from .length_bucket import LengthBucketedQueryEncoder
 from .sasrec import (
     DiffTransformerBlock,
     DiffTransformerLayer,

--- a/replay/nn/sequential/length_bucket.py
+++ b/replay/nn/sequential/length_bucket.py
@@ -1,0 +1,146 @@
+import torch
+
+from replay.data.nn import TensorMap
+
+
+class LengthBucketedQueryEncoder(torch.nn.Module):
+    """Evaluate similarly sized left-padded sequences together during training."""
+
+    def __init__(
+        self,
+        encoder: torch.nn.Module,
+        bucket_size: int,
+        prediction_shift: int = 1,
+        bucket_during_eval: bool = False,
+        min_input_elements: int = 4_194_304,
+    ) -> None:
+        """
+        :param encoder: query encoder accepting feature tensors, embeddings, padding mask and attention mask.
+        :param bucket_size: maximum number of rows evaluated together.
+        :param prediction_shift: number of positions retained before the first valid input token.
+        :param bucket_during_eval: whether to use bucketing outside training.
+        :param min_input_elements: minimum number of embedding elements required to use bucketing.
+            Set to ``0`` to enable bucketing for every batch.
+        """
+        super().__init__()
+        if bucket_size <= 0:
+            msg = "bucket_size must be positive"
+            raise ValueError(msg)
+        if prediction_shift < 0:
+            msg = "prediction_shift must be non-negative"
+            raise ValueError(msg)
+        if min_input_elements < 0:
+            msg = "min_input_elements must be non-negative"
+            raise ValueError(msg)
+        self.encoder = encoder
+        self.bucket_size = bucket_size
+        self.prediction_shift = prediction_shift
+        self.bucket_during_eval = bucket_during_eval
+        self.min_input_elements = min_input_elements
+
+    def reset_parameters(self) -> None:
+        reset_parameters = getattr(self.encoder, "reset_parameters", None)
+        if reset_parameters is not None:
+            reset_parameters()
+
+    @staticmethod
+    def _slice_features(
+        feature_tensors: TensorMap,
+        row_indices: torch.LongTensor,
+        left_crop: int,
+        batch_size: int,
+        sequence_length: int,
+    ) -> TensorMap:
+        result = {}
+        for name, value in feature_tensors.items():
+            if value.ndim == 0 or value.size(0) != batch_size:
+                result[name] = value
+                continue
+            value = value.index_select(0, row_indices)
+            if value.ndim >= 2 and value.size(1) == sequence_length:
+                value = value[:, left_crop:]
+            result[name] = value
+        return result
+
+    @staticmethod
+    def _slice_attention_mask(
+        attention_mask: torch.Tensor,
+        row_indices: torch.LongTensor,
+        left_crop: int,
+        batch_size: int,
+        sequence_length: int,
+    ) -> torch.Tensor:
+        mask = attention_mask
+        if mask.ndim >= 2 and mask.shape[-2:] == (sequence_length, sequence_length):
+            mask = mask[..., left_crop:, left_crop:]
+        if mask.ndim == 2:
+            return mask
+        if mask.size(0) == batch_size:
+            return mask.index_select(0, row_indices)
+        if mask.ndim == 3 and mask.size(0) % batch_size == 0:
+            num_heads = mask.size(0) // batch_size
+            mask = mask.reshape(batch_size, num_heads, *mask.shape[-2:])
+            return mask.index_select(0, row_indices).reshape(-1, *mask.shape[-2:])
+        return mask
+
+    def forward(
+        self,
+        feature_tensors: TensorMap,
+        input_embeddings: torch.Tensor,
+        padding_mask: torch.BoolTensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the wrapped encoder and restore the original row order."""
+        if input_embeddings.ndim != 3:
+            msg = "input_embeddings must have shape [batch, sequence, embedding]"
+            raise ValueError(msg)
+        if padding_mask.ndim != 2 or input_embeddings.shape[:2] != padding_mask.shape:
+            msg = "padding_mask must match the first two input_embeddings dimensions"
+            raise ValueError(msg)
+        batch_size, sequence_length = padding_mask.shape
+        if batch_size == 0:
+            msg = "batch dimension must be non-empty"
+            raise ValueError(msg)
+        if (not self.training and not self.bucket_during_eval) or (input_embeddings.numel() < self.min_input_elements):
+            return self.encoder(feature_tensors, input_embeddings, padding_mask, attention_mask)
+
+        lengths = padding_mask.sum(dim=1, dtype=torch.int32).detach().cpu().tolist()
+        order_list = sorted(range(batch_size), key=lengths.__getitem__)
+        order = torch.tensor(order_list, dtype=torch.long, device=padding_mask.device)
+        outputs = []
+        for start in range(0, batch_size, self.bucket_size):
+            end = min(start + self.bucket_size, batch_size)
+            row_indices = order[start:end]
+            max_valid_length = lengths[order_list[end - 1]]
+            left_crop = (
+                0 if max_valid_length == 0 else max(0, sequence_length - max_valid_length - self.prediction_shift)
+            )
+            bucket_embeddings = input_embeddings.index_select(0, row_indices)[:, left_crop:]
+            bucket_output = self.encoder(
+                self._slice_features(
+                    feature_tensors,
+                    row_indices,
+                    left_crop,
+                    batch_size,
+                    sequence_length,
+                ),
+                bucket_embeddings,
+                padding_mask.index_select(0, row_indices)[:, left_crop:],
+                self._slice_attention_mask(
+                    attention_mask,
+                    row_indices,
+                    left_crop,
+                    batch_size,
+                    sequence_length,
+                ),
+            )
+            if bucket_output.shape != bucket_embeddings.shape:
+                msg = "The wrapped encoder must preserve [batch, sequence, embedding] shape."
+                raise ValueError(msg)
+            if left_crop:
+                prefix = bucket_output.new_zeros(bucket_output.size(0), left_crop, bucket_output.size(2))
+                bucket_output = torch.cat((prefix, bucket_output), dim=1)
+            outputs.append(bucket_output)
+
+        sorted_output = torch.cat(outputs, dim=0)
+        return sorted_output.index_select(0, torch.argsort(order))

--- a/replay/nn/sequential/length_bucket.py
+++ b/replay/nn/sequential/length_bucket.py
@@ -4,7 +4,12 @@ from replay.data.nn import TensorMap
 
 
 class LengthBucketedQueryEncoder(torch.nn.Module):
-    """Evaluate similarly sized left-padded sequences together during training."""
+    """Evaluate similarly sized left-padded sequences together during training.
+
+    Cropped padding positions are restored as zeros. Downstream training code
+    must ignore them through its target mask. RePlay attention masks may be
+    shared, batch-aligned, or flattened as ``[batch * heads, sequence, sequence]``.
+    """
 
     def __init__(
         self,
@@ -40,7 +45,7 @@ class LengthBucketedQueryEncoder(torch.nn.Module):
 
     def reset_parameters(self) -> None:
         reset_parameters = getattr(self.encoder, "reset_parameters", None)
-        if reset_parameters is not None:
+        if callable(reset_parameters):
             reset_parameters()
 
     @staticmethod
@@ -71,8 +76,10 @@ class LengthBucketedQueryEncoder(torch.nn.Module):
         sequence_length: int,
     ) -> torch.Tensor:
         mask = attention_mask
-        if mask.ndim >= 2 and mask.shape[-2:] == (sequence_length, sequence_length):
-            mask = mask[..., left_crop:, left_crop:]
+        if mask.ndim < 2 or mask.shape[-2:] != (sequence_length, sequence_length):
+            msg = "attention_mask must end with [sequence, sequence] dimensions."
+            raise ValueError(msg)
+        mask = mask[..., left_crop:, left_crop:]
         if mask.ndim == 2:
             return mask
         if mask.size(0) == batch_size:
@@ -81,7 +88,8 @@ class LengthBucketedQueryEncoder(torch.nn.Module):
             num_heads = mask.size(0) // batch_size
             mask = mask.reshape(batch_size, num_heads, *mask.shape[-2:])
             return mask.index_select(0, row_indices).reshape(-1, *mask.shape[-2:])
-        return mask
+        msg = "attention_mask must be shared, batch-aligned, or flattened as [batch * heads, sequence, sequence]."
+        raise ValueError(msg)
 
     def forward(
         self,

--- a/tests/nn/sequential/test_length_bucket.py
+++ b/tests/nn/sequential/test_length_bucket.py
@@ -1,0 +1,91 @@
+import torch
+
+from replay.nn.sequential import LengthBucketedQueryEncoder
+
+
+class ToyEncoder(torch.nn.Module):
+    def __init__(self, embedding_dim: int) -> None:
+        super().__init__()
+        self.projection = torch.nn.Linear(embedding_dim, embedding_dim, bias=False)
+        self.input_shapes = []
+
+    def forward(self, feature_tensors, input_embeddings, padding_mask, attention_mask):
+        self.input_shapes.append(tuple(input_embeddings.shape))
+        assert feature_tensors["timestamp"].shape == padding_mask.shape
+        assert feature_tensors["request_id"].shape == padding_mask.shape[:1]
+        weights = torch.softmax(attention_mask[:, 0], dim=-1)
+        signal = feature_tensors["timestamp"].to(input_embeddings.dtype).unsqueeze(-1)
+        return self.projection(torch.bmm(weights, input_embeddings)) + signal * 1e-4
+
+
+def make_batch(lengths, sequence_length, embedding_dim):
+    positions = torch.arange(sequence_length).unsqueeze(0)
+    padding_mask = positions >= sequence_length - torch.tensor(lengths).unsqueeze(1)
+    batch_size = len(lengths)
+    embeddings = torch.randn(batch_size, sequence_length, embedding_dim)
+    timestamps = torch.arange(sequence_length).expand(batch_size, -1) + 1_700_000_000
+    features = {
+        "timestamp": torch.where(padding_mask, timestamps, 0),
+        "request_id": torch.arange(batch_size),
+    }
+    causal = torch.ones(sequence_length, sequence_length, dtype=torch.bool).tril()
+    diagonal = torch.eye(sequence_length, dtype=torch.bool)
+    allowed = causal[None] & (padding_mask[:, None, :] | diagonal[None])
+    attention_mask = torch.zeros_like(allowed, dtype=torch.float32).masked_fill(~allowed, -torch.inf)[:, None]
+    return features, embeddings, padding_mask, attention_mask
+
+
+def test_bucketed_active_outputs_and_gradients_match_full_batch():
+    torch.manual_seed(2)
+    features, baseline_embeddings, padding_mask, attention_mask = make_batch([2, 6, 3, 5, 1, 4], 7, 4)
+    baseline_embeddings.requires_grad_(True)
+    bucketed_embeddings = baseline_embeddings.detach().clone().requires_grad_(True)
+    baseline_encoder = ToyEncoder(4)
+    bucketed_encoder = ToyEncoder(4)
+    bucketed_encoder.load_state_dict(baseline_encoder.state_dict())
+    wrapper = LengthBucketedQueryEncoder(bucketed_encoder, bucket_size=2, min_input_elements=0)
+
+    baseline_output = baseline_encoder(features, baseline_embeddings, padding_mask, attention_mask)
+    bucketed_output = wrapper(features, bucketed_embeddings, padding_mask, attention_mask)
+    active = padding_mask.unsqueeze(-1).expand_as(baseline_output)
+    torch.testing.assert_close(bucketed_output[active], baseline_output[active])
+
+    baseline_output[active].square().sum().backward()
+    bucketed_output[active].square().sum().backward()
+    torch.testing.assert_close(bucketed_embeddings.grad, baseline_embeddings.grad)
+    torch.testing.assert_close(
+        bucketed_encoder.projection.weight.grad,
+        baseline_encoder.projection.weight.grad,
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    assert bucketed_encoder.input_shapes == [(2, 3, 4), (2, 5, 4), (2, 7, 4)]
+
+
+def test_bucketed_encoder_keeps_shifted_target_boundary():
+    torch.manual_seed(4)
+    features, embeddings, padding_mask, attention_mask = make_batch([1, 3, 5], 6, 3)
+    baseline_encoder = ToyEncoder(3)
+    bucketed_encoder = ToyEncoder(3)
+    bucketed_encoder.load_state_dict(baseline_encoder.state_dict())
+    wrapper = LengthBucketedQueryEncoder(bucketed_encoder, bucket_size=1, prediction_shift=1, min_input_elements=0)
+    target_mask = torch.cat((padding_mask[:, 1:], padding_mask[:, -1:]), dim=1)
+
+    expected = baseline_encoder(features, embeddings, padding_mask, attention_mask)
+    actual = wrapper(features, embeddings, padding_mask, attention_mask)
+
+    active = target_mask.unsqueeze(-1).expand_as(expected)
+    torch.testing.assert_close(actual[active], expected[active])
+    assert bucketed_encoder.input_shapes == [(1, 2, 3), (1, 4, 3), (1, 6, 3)]
+
+
+def test_bucketed_encoder_bypasses_small_and_evaluation_batches():
+    features, embeddings, padding_mask, attention_mask = make_batch([1, 3], 4, 2)
+    encoder = ToyEncoder(2)
+    wrapper = LengthBucketedQueryEncoder(encoder, bucket_size=1, min_input_elements=100).train()
+
+    wrapper(features, embeddings, padding_mask, attention_mask)
+    wrapper.min_input_elements = 0
+    wrapper.eval()(features, embeddings, padding_mask, attention_mask)
+
+    assert encoder.input_shapes == [(2, 4, 2), (2, 4, 2)]

--- a/tests/nn/sequential/test_length_bucket.py
+++ b/tests/nn/sequential/test_length_bucket.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from replay.nn.sequential import LengthBucketedQueryEncoder
@@ -89,3 +90,35 @@ def test_bucketed_encoder_bypasses_small_and_evaluation_batches():
     wrapper.eval()(features, embeddings, padding_mask, attention_mask)
 
     assert encoder.input_shapes == [(2, 4, 2), (2, 4, 2)]
+
+
+def test_bucketed_encoder_slices_flattened_multihead_mask_by_row():
+    batch_size, num_heads, sequence_length = 3, 2, 5
+    mask = torch.arange(batch_size * num_heads * sequence_length**2).reshape(
+        batch_size * num_heads,
+        sequence_length,
+        sequence_length,
+    )
+    row_indices = torch.tensor([2, 0])
+
+    actual = LengthBucketedQueryEncoder._slice_attention_mask(
+        mask,
+        row_indices,
+        left_crop=2,
+        batch_size=batch_size,
+        sequence_length=sequence_length,
+    )
+    expected = mask.reshape(batch_size, num_heads, sequence_length, sequence_length)[row_indices, :, 2:, 2:]
+
+    torch.testing.assert_close(actual, expected.reshape(-1, 3, 3))
+
+
+def test_bucketed_encoder_rejects_unsupported_attention_mask_layout():
+    with pytest.raises(ValueError, match="batch-aligned"):
+        LengthBucketedQueryEncoder._slice_attention_mask(
+            torch.zeros(1, 2, 4, 4),
+            torch.tensor([0]),
+            left_crop=0,
+            batch_size=3,
+            sequence_length=4,
+        )

--- a/tests/nn/sequential/test_length_bucket.py
+++ b/tests/nn/sequential/test_length_bucket.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from replay.nn.sequential import LengthBucketedQueryEncoder
+from replay.nn.sequential import LengthBucketedQueryEncoder, SasRecTransformerLayer
 
 
 class ToyEncoder(torch.nn.Module):
@@ -122,3 +122,24 @@ def test_bucketed_encoder_rejects_unsupported_attention_mask_layout():
             batch_size=3,
             sequence_length=4,
         )
+
+
+def test_bucketed_sasrec_matches_full_batch_with_flattened_multihead_mask():
+    torch.manual_seed(8)
+    features, baseline_embeddings, padding_mask, attention_mask = make_batch([2, 6, 3, 5], 7, 4)
+    baseline_embeddings.requires_grad_(True)
+    bucketed_embeddings = baseline_embeddings.detach().clone().requires_grad_(True)
+    baseline_encoder = SasRecTransformerLayer(embedding_dim=4, num_heads=2, num_blocks=1, dropout=0.0)
+    bucketed_encoder = SasRecTransformerLayer(embedding_dim=4, num_heads=2, num_blocks=1, dropout=0.0)
+    bucketed_encoder.load_state_dict(baseline_encoder.state_dict())
+    wrapper = LengthBucketedQueryEncoder(bucketed_encoder, bucket_size=2, min_input_elements=0)
+    multihead_mask = attention_mask[:, 0].repeat_interleave(2, dim=0)
+
+    baseline_output = baseline_encoder(features, baseline_embeddings, padding_mask, multihead_mask)
+    bucketed_output = wrapper(features, bucketed_embeddings, padding_mask, multihead_mask)
+    active = padding_mask.unsqueeze(-1).expand_as(baseline_output)
+    torch.testing.assert_close(bucketed_output[active], baseline_output[active], rtol=1e-5, atol=1e-6)
+
+    baseline_output[active].square().sum().backward()
+    bucketed_output[active].square().sum().backward()
+    torch.testing.assert_close(bucketed_embeddings.grad, baseline_embeddings.grad, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

Adds an opt-in wrapper that evaluates similarly sized left-padded query
sequences together. It sorts rows by valid length, crops padding separately for
each bucket, invokes the wrapped encoder, restores the original sequence width,
and returns rows in their original order.

Negative sampling and loss grouping still see the original physical batch.
Only the quadratic query-encoder computation is split. `prediction_shift`
keeps positions needed by shifted next-token targets.

## Example

With `bucket_size=2`, valid lengths `[2, 6, 3, 5, 1, 4]` and source width 7,
the wrapped encoder receives three tensors with widths 3, 5 and 7 instead of
processing all six rows at width 7. Active outputs and gradients match the
unbucketed encoder; values in the discarded padding prefix are restored as
zeros and never participate in the loss.

```python
query_encoder = LengthBucketedQueryEncoder(
    encoder=query_encoder,
    bucket_size=96,
    prediction_shift=1,
)
```

Evaluation bypasses bucketing by default. Existing encoders are unchanged.

## Performance evidence

A controlled production-like TwoTower benchmark used 2 NVIDIA A100 80 GiB
GPUs, FP32, a physical batch of 512 and sequences of length 400. Adding length
buckets of at most 96 rows changed training throughput from 2,126.4 to 3,353.0
samples/s (1.577x) and peak allocated memory from 38.55 to 31.90 GiB per GPU
(-17.25%). Each measurement used 3 warm-up and 6 measured batches per rank.
The GPU measurement was collected in the downstream implementation from which
this public wrapper was ported. The public branch was revalidated for output
and gradient parity, but was not remeasured on A100 after the port.

## Validation

- active outputs and input/parameter gradients match the full-batch encoder;
- shifted target boundaries, row order, feature and attention-mask slicing,
  small-batch bypass and evaluation bypass are covered;
- flattened multi-head masks are sliced by user, while unsupported layouts fail
  explicitly instead of being forwarded with the wrong rows;
- 28 related TwoTower and wrapper tests passed;
- Ruff checks for the affected files and `git diff --check` passed.
