### PR TITLE
Epoch-only synchronization of training metrics

### DIFF
--- a/replay/nn/lightning/module.py
+++ b/replay/nn/lightning/module.py
@@ -49,6 +49,9 @@ class LightningModule(lightning.LightningModule):
         self.candidates_to_score = None
         self.epoch_only_training_metrics = epoch_only_training_metrics
         self.training_batch_size_feature_name = training_batch_size_feature_name
+        self.register_buffer("_train_loss_sum", torch.zeros((), dtype=torch.float64), persistent=False)
+        self.register_buffer("_learning_rate_sum", torch.zeros((), dtype=torch.float64), persistent=False)
+        self.register_buffer("_training_row_count", torch.zeros((), dtype=torch.float64), persistent=False)
 
     def forward(self, batch: dict) -> TrainOutput | InferenceOutput:
         """
@@ -88,12 +91,10 @@ class LightningModule(lightning.LightningModule):
 
     def _infer_training_batch_size(self, batch: Mapping[str, Any]) -> int:
         feature_tensors = batch.get("feature_tensors")
-        if not isinstance(feature_tensors, Mapping):
-            msg = "Training batch must contain a 'feature_tensors' mapping."
-            raise ValueError(msg)
+        batch_tensors = feature_tensors if isinstance(feature_tensors, Mapping) else batch
         feature_name = self.training_batch_size_feature_name
         if feature_name is not None:
-            feature = feature_tensors.get(feature_name)
+            feature = batch_tensors.get(feature_name)
             if not isinstance(feature, torch.Tensor) or feature.ndim == 0:
                 msg = f"Batch-size feature '{feature_name}' must be a non-scalar tensor."
                 raise ValueError(msg)
@@ -101,12 +102,12 @@ class LightningModule(lightning.LightningModule):
         else:
             batch_sizes = {
                 int(value.shape[0])
-                for value in feature_tensors.values()
+                for value in batch_tensors.values()
                 if isinstance(value, torch.Tensor) and value.ndim > 0
             }
             if len(batch_sizes) != 1:
                 msg = (
-                    "Feature tensors must have one common batch size. Set "
+                    "Batch tensors must have one common batch size. Set "
                     "training_batch_size_feature_name when the mapping contains shared tensors."
                 )
                 raise ValueError(msg)
@@ -121,28 +122,75 @@ class LightningModule(lightning.LightningModule):
         loss = model_output["loss"]
         learning_rate = self.optimizers().param_groups[0]["lr"]
         batch_size = self._infer_training_batch_size(batch)
-        detached_learning_rate = torch.as_tensor(learning_rate, device=self.device)
+        detached_loss = loss.detach().to(device=self._train_loss_sum.device, dtype=self._train_loss_sum.dtype)
+        detached_learning_rate = torch.as_tensor(
+            learning_rate,
+            device=self._learning_rate_sum.device,
+            dtype=self._learning_rate_sum.dtype,
+        )
+        self._train_loss_sum.add_(detached_loss * batch_size)
+        self._learning_rate_sum.add_(detached_learning_rate * batch_size)
+        self._training_row_count.add_(batch_size)
 
-        self.log(
-            "learning_rate_epoch",
-            detached_learning_rate,
-            on_step=False,
-            on_epoch=True,
-            prog_bar=True,
-            sync_dist=True,
-            batch_size=batch_size,
-        )
-        self.log(
-            "train_loss_epoch",
-            loss,
-            on_step=False,
-            on_epoch=True,
-            prog_bar=True,
-            sync_dist=True,
-            batch_size=batch_size,
-        )
+        if self.global_rank == 0:
+            self.log(
+                "learning_rate_step",
+                detached_learning_rate,
+                on_step=True,
+                on_epoch=False,
+                prog_bar=True,
+                sync_dist=False,
+                rank_zero_only=True,
+                batch_size=batch_size,
+            )
+            self.log(
+                "train_loss_step",
+                detached_loss,
+                on_step=True,
+                on_epoch=False,
+                prog_bar=True,
+                sync_dist=False,
+                rank_zero_only=True,
+                batch_size=batch_size,
+            )
 
         return loss
+
+    def on_train_epoch_start(self) -> None:
+        if self.epoch_only_training_metrics:
+            self._train_loss_sum.zero_()
+            self._learning_rate_sum.zero_()
+            self._training_row_count.zero_()
+        super().on_train_epoch_start()
+
+    def on_train_epoch_end(self) -> None:
+        if self.epoch_only_training_metrics:
+            totals = torch.stack((self._train_loss_sum, self._learning_rate_sum, self._training_row_count))
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                torch.distributed.all_reduce(totals, op=torch.distributed.ReduceOp.SUM)
+            if totals[2].item() <= 0:
+                msg = "Cannot aggregate training metrics without rows."
+                raise RuntimeError(msg)
+            if self.global_rank == 0:
+                self.log(
+                    "train_loss_epoch",
+                    totals[0] / totals[2],
+                    on_step=False,
+                    on_epoch=True,
+                    prog_bar=True,
+                    sync_dist=False,
+                    rank_zero_only=True,
+                )
+                self.log(
+                    "learning_rate_epoch",
+                    totals[1] / totals[2],
+                    on_step=False,
+                    on_epoch=True,
+                    prog_bar=True,
+                    sync_dist=False,
+                    rank_zero_only=True,
+                )
+        super().on_train_epoch_end()
 
     @override
     def predict_step(self, batch: dict, batch_idx: int, dataloader_idx: int = 0) -> torch.Tensor:

--- a/replay/nn/lightning/module.py
+++ b/replay/nn/lightning/module.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Mapping
 from typing import Any
 
 import lightning
@@ -21,6 +22,9 @@ class LightningModule(lightning.LightningModule):
         model: torch.nn.Module,
         optimizer_factory: BaseOptimizerFactory | None = None,
         lr_scheduler_factory: BaseLRSchedulerFactory | None = None,
+        *,
+        epoch_only_training_metrics: bool = False,
+        training_batch_size_feature_name: str | None = None,
     ) -> None:
         """
         :param model: Initialized model.\n
@@ -31,6 +35,10 @@ class LightningModule(lightning.LightningModule):
             Default: ``None``.
         :param lr_scheduler_factory: The learning rate schedule factory.
             Default: ``None``.
+        :param epoch_only_training_metrics: accumulate training metrics locally and synchronize them
+            at epoch end instead of every step. Default: ``False``.
+        :param training_batch_size_feature_name: feature used to determine batch size when
+            epoch-level reduction is enabled. By default all tensors in ``feature_tensors`` are checked.
         """
         super().__init__()
         self.save_hyperparameters(ignore=["model"])
@@ -39,6 +47,8 @@ class LightningModule(lightning.LightningModule):
         self._optimizer_factory = optimizer_factory
         self._lr_scheduler_factory = lr_scheduler_factory
         self.candidates_to_score = None
+        self.epoch_only_training_metrics = epoch_only_training_metrics
+        self.training_batch_size_feature_name = training_batch_size_feature_name
 
     def forward(self, batch: dict) -> TrainOutput | InferenceOutput:
         """
@@ -60,6 +70,8 @@ class LightningModule(lightning.LightningModule):
         return self.model(**modified_batch)
 
     def training_step(self, batch: dict) -> torch.Tensor:
+        if self.epoch_only_training_metrics:
+            return self._training_step_with_epoch_metrics(batch)
         model_output: TrainOutput = self(batch)
         loss = model_output["loss"]
         lr = self.optimizers().param_groups[0]["lr"]  # Get current learning rate
@@ -72,6 +84,64 @@ class LightningModule(lightning.LightningModule):
             prog_bar=True,
             sync_dist=True,
         )
+        return loss
+
+    def _infer_training_batch_size(self, batch: Mapping[str, Any]) -> int:
+        feature_tensors = batch.get("feature_tensors")
+        if not isinstance(feature_tensors, Mapping):
+            msg = "Training batch must contain a 'feature_tensors' mapping."
+            raise ValueError(msg)
+        feature_name = self.training_batch_size_feature_name
+        if feature_name is not None:
+            feature = feature_tensors.get(feature_name)
+            if not isinstance(feature, torch.Tensor) or feature.ndim == 0:
+                msg = f"Batch-size feature '{feature_name}' must be a non-scalar tensor."
+                raise ValueError(msg)
+            batch_sizes = {int(feature.shape[0])}
+        else:
+            batch_sizes = {
+                int(value.shape[0])
+                for value in feature_tensors.values()
+                if isinstance(value, torch.Tensor) and value.ndim > 0
+            }
+            if len(batch_sizes) != 1:
+                msg = (
+                    "Feature tensors must have one common batch size. Set "
+                    "training_batch_size_feature_name when the mapping contains shared tensors."
+                )
+                raise ValueError(msg)
+        batch_size = batch_sizes.pop()
+        if batch_size <= 0:
+            msg = f"Training batch size must be positive, got {batch_size}."
+            raise ValueError(msg)
+        return batch_size
+
+    def _training_step_with_epoch_metrics(self, batch: dict) -> torch.Tensor:
+        model_output: TrainOutput = self(batch)
+        loss = model_output["loss"]
+        learning_rate = self.optimizers().param_groups[0]["lr"]
+        batch_size = self._infer_training_batch_size(batch)
+        detached_learning_rate = torch.as_tensor(learning_rate, device=self.device)
+
+        self.log(
+            "learning_rate_epoch",
+            detached_learning_rate,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+            batch_size=batch_size,
+        )
+        self.log(
+            "train_loss_epoch",
+            loss,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            sync_dist=True,
+            batch_size=batch_size,
+        )
+
         return loss
 
     @override

--- a/tests/nn/lightning/test_epoch_training_metrics.py
+++ b/tests/nn/lightning/test_epoch_training_metrics.py
@@ -22,6 +22,11 @@ class ConstantLossModel(LossModel):
         return {"loss": self.scale * 0 + 4}
 
 
+class BatchMeanLossModel(LossModel):
+    def forward(self, feature_tensors):
+        return {"loss": self.scale * 0 + feature_tensors["value"].float().mean()}
+
+
 def make_batch(batch_size):
     return {
         "feature_tensors": {
@@ -45,7 +50,7 @@ def test_default_training_step_keeps_existing_logging():
     assert all(call.kwargs["sync_dist"] is True for call in log.call_args_list)
 
 
-def test_epoch_mode_defers_distributed_metrics_and_preserves_weights():
+def test_epoch_mode_uses_rank_zero_step_metrics_without_synchronization():
     module = LightningModule(ConstantLossModel(2.0), epoch_only_training_metrics=True)
     module._trainer = SimpleNamespace(global_rank=0)
 
@@ -54,11 +59,12 @@ def test_epoch_mode_defers_distributed_metrics_and_preserves_weights():
             loss = module.training_step(make_batch(3))
 
     assert loss.requires_grad
-    assert [call.args[0] for call in log.call_args_list] == ["learning_rate_epoch", "train_loss_epoch"]
+    assert [call.args[0] for call in log.call_args_list] == ["learning_rate_step", "train_loss_step"]
     for call in log.call_args_list:
-        assert call.kwargs["on_step"] is False
-        assert call.kwargs["on_epoch"] is True
-        assert call.kwargs["sync_dist"] is True
+        assert call.kwargs["on_step"] is True
+        assert call.kwargs["on_epoch"] is False
+        assert call.kwargs["sync_dist"] is False
+        assert call.kwargs["rank_zero_only"] is True
         assert call.kwargs["batch_size"] == 3
 
 
@@ -80,9 +86,9 @@ def test_epoch_mode_uses_named_batch_feature_for_shared_tensors():
 
 
 def test_epoch_mode_reports_metrics_with_lightning_trainer():
-    module = LightningModule(ConstantLossModel(2.0), epoch_only_training_metrics=True)
+    module = LightningModule(BatchMeanLossModel(2.0), epoch_only_training_metrics=True)
     dataloader = DataLoader(
-        [{"feature_tensors": {"item_id": torch.tensor([item_id])}} for item_id in range(5)],
+        [{"feature_tensors": {"value": torch.tensor(float(item_id))}} for item_id in range(5)],
         batch_size=2,
     )
     trainer = lightning.Trainer(
@@ -95,5 +101,11 @@ def test_epoch_mode_reports_metrics_with_lightning_trainer():
 
     trainer.fit(module, train_dataloaders=dataloader)
 
-    torch.testing.assert_close(trainer.callback_metrics["train_loss_epoch"], torch.tensor(4.0))
+    torch.testing.assert_close(trainer.callback_metrics["train_loss_epoch"], torch.tensor(2.0, dtype=torch.float64))
     assert "learning_rate_epoch" in trainer.callback_metrics
+
+
+def test_epoch_mode_infers_batch_size_from_top_level_tensors():
+    module = LightningModule(LossModel(1.0), epoch_only_training_metrics=True)
+
+    assert module._infer_training_batch_size({"item_id": torch.zeros(3, 4, dtype=torch.long)}) == 3

--- a/tests/nn/lightning/test_epoch_training_metrics.py
+++ b/tests/nn/lightning/test_epoch_training_metrics.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import lightning
+import torch
+from torch.utils.data import DataLoader
+
+from replay.nn.lightning import LightningModule
+
+
+class LossModel(torch.nn.Module):
+    def __init__(self, loss: float) -> None:
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.tensor(loss))
+
+    def forward(self, feature_tensors):
+        return {"loss": self.scale.square()}
+
+
+class ConstantLossModel(LossModel):
+    def forward(self, feature_tensors):
+        return {"loss": self.scale * 0 + 4}
+
+
+def make_batch(batch_size):
+    return {
+        "feature_tensors": {
+            "item_id": torch.zeros(batch_size, 4, dtype=torch.long),
+            "timestamp": torch.ones(batch_size, 4, dtype=torch.long),
+        },
+        "negative_labels": torch.arange(40_000),
+    }
+
+
+def test_default_training_step_keeps_existing_logging():
+    module = LightningModule(LossModel(2.0))
+    module._trainer = SimpleNamespace(global_rank=0)
+
+    with patch.object(module, "optimizers", return_value=SimpleNamespace(param_groups=[{"lr": 0.01}])):
+        with patch.object(module, "log") as log:
+            loss = module.training_step(make_batch(2))
+
+    assert loss.requires_grad
+    assert [call.args[0] for call in log.call_args_list] == ["learning_rate", "train_loss"]
+    assert all(call.kwargs["sync_dist"] is True for call in log.call_args_list)
+
+
+def test_epoch_mode_defers_distributed_metrics_and_preserves_weights():
+    module = LightningModule(ConstantLossModel(2.0), epoch_only_training_metrics=True)
+    module._trainer = SimpleNamespace(global_rank=0)
+
+    with patch.object(module, "optimizers", return_value=SimpleNamespace(param_groups=[{"lr": 0.01}])):
+        with patch.object(module, "log") as log:
+            loss = module.training_step(make_batch(3))
+
+    assert loss.requires_grad
+    assert [call.args[0] for call in log.call_args_list] == ["learning_rate_epoch", "train_loss_epoch"]
+    for call in log.call_args_list:
+        assert call.kwargs["on_step"] is False
+        assert call.kwargs["on_epoch"] is True
+        assert call.kwargs["sync_dist"] is True
+        assert call.kwargs["batch_size"] == 3
+
+
+def test_epoch_mode_uses_named_batch_feature_for_shared_tensors():
+    module = LightningModule(
+        LossModel(1.0),
+        epoch_only_training_metrics=True,
+        training_batch_size_feature_name="item_id",
+    )
+    module._trainer = SimpleNamespace(global_rank=0)
+    batch = make_batch(3)
+    batch["feature_tensors"]["shared_negatives"] = torch.arange(50)
+
+    with patch.object(module, "optimizers", return_value=SimpleNamespace(param_groups=[{"lr": 0.01}])):
+        with patch.object(module, "log") as log:
+            module.training_step(batch)
+
+    assert all(call.kwargs["batch_size"] == 3 for call in log.call_args_list)
+
+
+def test_epoch_mode_reports_metrics_with_lightning_trainer():
+    module = LightningModule(ConstantLossModel(2.0), epoch_only_training_metrics=True)
+    dataloader = DataLoader(
+        [{"feature_tensors": {"item_id": torch.tensor([item_id])}} for item_id in range(5)],
+        batch_size=2,
+    )
+    trainer = lightning.Trainer(
+        max_epochs=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+
+    trainer.fit(module, train_dataloaders=dataloader)
+
+    torch.testing.assert_close(trainer.callback_metrics["train_loss_epoch"], torch.tensor(4.0))
+    assert "learning_rate_epoch" in trainer.callback_metrics

--- a/tests/nn/lightning/test_epoch_training_metrics.py
+++ b/tests/nn/lightning/test_epoch_training_metrics.py
@@ -1,7 +1,11 @@
+import socket
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import lightning
+import pytest
 import torch
 from torch.utils.data import DataLoader
 
@@ -35,6 +39,41 @@ def make_batch(batch_size):
         },
         "negative_labels": torch.arange(40_000),
     }
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _distributed_epoch_metrics_worker(rank: int, port: int, output_dir: str) -> None:
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=2,
+    )
+    module = LightningModule(LossModel(1.0), epoch_only_training_metrics=True)
+    module._trainer = SimpleNamespace(global_rank=rank)
+    module._train_loss_sum.fill_(10 + 2 * rank)
+    module._learning_rate_sum.fill_(0.2 + 0.4 * rank)
+    module._training_row_count.fill_(2 + rank)
+    reduction_count = 0
+    original_all_reduce = torch.distributed.all_reduce
+
+    def counted_all_reduce(*args, **kwargs):
+        nonlocal reduction_count
+        reduction_count += 1
+        return original_all_reduce(*args, **kwargs)
+
+    with patch.object(torch.distributed, "all_reduce", side_effect=counted_all_reduce):
+        with patch.object(module, "log") as log:
+            module.on_train_epoch_end()
+
+    logged = {call.args[0]: float(call.args[1]) for call in log.call_args_list}
+    torch.save((reduction_count, logged), Path(output_dir) / f"rank-{rank}.pt")
+    torch.distributed.destroy_process_group()
 
 
 def test_default_training_step_keeps_existing_logging():
@@ -109,3 +148,22 @@ def test_epoch_mode_infers_batch_size_from_top_level_tensors():
     module = LightningModule(LossModel(1.0), epoch_only_training_metrics=True)
 
     assert module._infer_training_batch_size({"item_id": torch.zeros(3, 4, dtype=torch.long)}) == 3
+
+
+def test_epoch_mode_reduces_metrics_once_in_two_process_ddp():
+    with tempfile.TemporaryDirectory() as output_dir:
+        torch.multiprocessing.spawn(
+            _distributed_epoch_metrics_worker,
+            args=(_free_port(), output_dir),
+            nprocs=2,
+            join=True,
+        )
+        results = {
+            rank: torch.load(Path(output_dir) / f"rank-{rank}.pt", weights_only=True)
+            for rank in range(2)
+        }
+
+    assert results[0][0] == results[1][0] == 1
+    assert results[0][1]["train_loss_epoch"] == pytest.approx(4.4)
+    assert results[0][1]["learning_rate_epoch"] == pytest.approx(0.16)
+    assert results[1][1] == {}

--- a/tests/nn/lightning/test_epoch_training_metrics.py
+++ b/tests/nn/lightning/test_epoch_training_metrics.py
@@ -158,10 +158,7 @@ def test_epoch_mode_reduces_metrics_once_in_two_process_ddp():
             nprocs=2,
             join=True,
         )
-        results = {
-            rank: torch.load(Path(output_dir) / f"rank-{rank}.pt", weights_only=True)
-            for rank in range(2)
-        }
+        results = {rank: torch.load(Path(output_dir) / f"rank-{rank}.pt", weights_only=True) for rank in range(2)}
 
     assert results[0][0] == results[1][0] == 1
     assert results[0][1]["train_loss_epoch"] == pytest.approx(4.4)


### PR DESCRIPTION
## Summary

Adds `epoch_only_training_metrics=True` to the universal Lightning wrapper.
The option accumulates loss and learning rate locally, packs their sums and the
row count into one tensor, and performs one distributed reduction at epoch end.
Rank zero still reports step metrics without distributed synchronization. The
default logging path is unchanged.

## Example

In a distributed epoch with 1,951 batches, the current path logs two metrics
with `sync_dist=True` on every step, causing 3,902 step-time collective
reductions. Epoch-only synchronization removes those collectives from the hot
path and replaces them with one `all_reduce` of three scalar values at epoch
end.

```python
module = LightningModule(
    model,
    epoch_only_training_metrics=True,
    training_batch_size_feature_name="item_id",
)
```

`training_batch_size_feature_name` is only needed when the batch tensor mapping
contains tensors with different leading dimensions. Nested `feature_tensors`
and ordinary top-level tensor batches are supported. Metric values remain
weighted by the number of rows, including a short final batch.

## Validation

- an actual one-epoch Lightning `Trainer.fit` run verifies the reported metric
  names and row-weighted values with a short final batch;
- unit tests verify the unchanged default path, deferred synchronization
  options, top-level batches and explicit batch-size selection;
- 6 focused Lightning tests passed;
- Ruff checks for the affected files and `git diff --check` passed.

No standalone end-to-end speedup is claimed for this PR because the benefit
depends on the distributed interconnect and the number of training steps.
