### PR TITLE
Copy-free embedding tying

### DIFF
--- a/replay/nn/head.py
+++ b/replay/nn/head.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as functional
 
 
 class EmbeddingTyingHead(torch.nn.Module):
@@ -27,19 +28,15 @@ class EmbeddingTyingHead(torch.nn.Module):
             or ``(batch_size, sequence_length, num_items)``.
         """
         if item_embeddings.dim() == 2:
-            item_embeddings = item_embeddings.transpose(-1, -2).contiguous()
             # hidden_states shape [B, *, E]
             # item embeddings shape [I, E]
             # [B, *, E] x [E, I] -> [B, *, I]
-            return hidden_states.matmul(item_embeddings)
+            return functional.linear(hidden_states, item_embeddings)
         elif item_embeddings.dim() == 3 and hidden_states.dim() == 2:
-            item_embeddings = item_embeddings.transpose(-1, -2).contiguous()
             # out_embeddings shape [B, E]
             # item embeddings shape [B, I, E]
             # [B, E] x [B, E, I] -> [B, I]
-            hidden_states = hidden_states.unsqueeze(-2)
-            logits = hidden_states.matmul(item_embeddings)
-            return logits.squeeze(-2)
+            return torch.bmm(item_embeddings, hidden_states.unsqueeze(-1)).squeeze(-1)
         # out_embeddings shape: [B, *, E]
         # item embeddings shape [B, *, E]
         # [*, 1, E] x [*, E, 1] -> [B, *]

--- a/tests/nn/test_head.py
+++ b/tests/nn/test_head.py
@@ -21,3 +21,30 @@ def test_head_forward(shape_hidden, shape_embeddings, expected_shape):
     scores = head(hidden_states, item_embeddings)
 
     assert scores.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "shape_hidden, shape_embeddings",
+    [
+        ((4, 3, 8), (100, 8)),
+        ((4, 8), (4, 100, 8)),
+    ],
+)
+def test_head_matches_transposed_matmul(shape_hidden, shape_embeddings):
+    hidden_states = torch.randn(shape_hidden, requires_grad=True)
+    item_embeddings = torch.randn(shape_embeddings, requires_grad=True)
+    reference_hidden_states = hidden_states.detach().clone().requires_grad_()
+    reference_item_embeddings = item_embeddings.detach().clone().requires_grad_()
+
+    actual = EmbeddingTyingHead()(hidden_states, item_embeddings)
+    transposed_embeddings = reference_item_embeddings.transpose(-1, -2).contiguous()
+    if reference_item_embeddings.dim() == 3:
+        reference = reference_hidden_states.unsqueeze(-2).matmul(transposed_embeddings).squeeze(-2)
+    else:
+        reference = reference_hidden_states.matmul(transposed_embeddings)
+    actual.sum().backward()
+    reference.sum().backward()
+
+    torch.testing.assert_close(actual, reference)
+    torch.testing.assert_close(hidden_states.grad, reference_hidden_states.grad)
+    torch.testing.assert_close(item_embeddings.grad, reference_item_embeddings.grad)


### PR DESCRIPTION
## Summary

Removes explicit transposed contiguous copies from `EmbeddingTyingHead`.
Two-dimensional item matrices are scored with `torch.nn.functional.linear`;
batched candidate matrices use `torch.bmm`. The public API, tensor shapes,
state dictionaries and mathematical operation remain unchanged.

## Example

For a catalog of 898,765 items with 192-dimensional FP32 embeddings, the old
full-catalog path materializes a contiguous transposed tensor of about 658 MiB
before scoring. The new path passes the original `[items, embedding_dim]`
matrix directly to the linear kernel and avoids that explicit allocation on
every call.

No configuration change is required: existing SASRec and TwoTower models use
the optimized implementation automatically.

## Validation

- output and gradient parity is checked for shared 2D catalogs and per-row 3D
  candidate matrices;
- all existing head and sampled-loss tests pass: 48 tests total;
- Ruff checks for the affected files and `git diff --check` passed.

The memory figure above is the eliminated tensor size, not a claim about total
model memory. No standalone throughput claim is made because kernel choice and
catalog size determine the runtime effect.
