### PR TITLE
Packed TwoTower training with stable negative pools

### DIFF
--- a/docs/pages/modules/redesigned_nn_models.rst
+++ b/docs/pages/modules/redesigned_nn_models.rst
@@ -125,6 +125,16 @@ __________
 .. autoclass:: replay.nn.loss.CESampled
    :members: __init__, forward
 
+GroupedCESampled
+________________
+.. autoclass:: replay.nn.loss.GroupedCESampled
+   :members: __init__, forward
+
+CatalogCachedGroupedCESampled
+_____________________________
+.. autoclass:: replay.nn.loss.CatalogCachedGroupedCESampled
+   :members: __init__, forward
+
 .. _loss-login-ce:
 
 LogInCE
@@ -246,6 +256,11 @@ _______________
 .. autoclass:: replay.nn.lightning.LightningModule
    :members: __init__, forward, candidates_to_score
 
+CatalogCacheLightningModule
+___________________________
+.. autoclass:: replay.nn.lightning.CatalogCacheLightningModule
+   :members: __init__, forward, candidates_to_score
+
 TrainOutput
 ___________
 .. autoclass:: replay.nn.output.TrainOutput
@@ -343,6 +358,11 @@ ______________________
 UniformNegativeSamplingTransform
 _________________________________
 .. autoclass:: replay.nn.transform.UniformNegativeSamplingTransform
+    :members: __init__
+
+GroupedUniformNegativeSamplingTransform
+________________________________________
+.. autoclass:: replay.nn.transform.GroupedUniformNegativeSamplingTransform
     :members: __init__
 
 MultiClassNegativeSamplingTransform

--- a/replay/nn/lightning/__init__.py
+++ b/replay/nn/lightning/__init__.py
@@ -1,1 +1,4 @@
+from .catalog_cache import CatalogCacheLightningModule
 from .module import LightningModule
+
+__all__ = ["CatalogCacheLightningModule", "LightningModule"]

--- a/replay/nn/lightning/catalog_cache.py
+++ b/replay/nn/lightning/catalog_cache.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+import torch
+
+from replay.nn.lightning.module import LightningModule
+
+
+class CatalogCacheLightningModule(LightningModule):
+    """Lightning wrapper for a loss that caches the item catalog across accumulation."""
+
+    def _is_accumulation_window_end(self, batch_idx: int) -> bool:
+        accumulation_steps = self.trainer.accumulate_grad_batches
+        is_last_batch = batch_idx + 1 == self.trainer.num_training_batches
+        return (batch_idx + 1) % accumulation_steps == 0 or is_last_batch
+
+    def training_step(self, batch: dict, batch_idx: int) -> torch.Tensor:
+        accumulation_steps = self.trainer.accumulate_grad_batches
+        self.model.loss.prepare_accumulation_microbatch(
+            is_window_end=self._is_accumulation_window_end(batch_idx),
+            trainer_accumulation_steps=accumulation_steps,
+            global_step=self.global_step,
+        )
+        return super().training_step(batch)
+
+    def backward(self, loss: torch.Tensor, *args: Any, **kwargs: Any) -> None:
+        if "retain_graph" in kwargs:
+            msg = "CatalogCacheLightningModule controls retain_graph during accumulation."
+            raise ValueError(msg)
+        kwargs["retain_graph"] = self.model.loss.should_retain_graph_for_current_backward()
+        super().backward(loss, *args, **kwargs)
+
+    def on_after_backward(self) -> None:
+        self.model.loss.assert_current_backward_completed()
+        super().on_after_backward()
+
+    def on_train_epoch_start(self) -> None:
+        self.model.loss.assert_accumulation_cache_idle()
+        super().on_train_epoch_start()
+
+    def on_train_epoch_end(self) -> None:
+        self.model.loss.assert_accumulation_cache_idle()
+        super().on_train_epoch_end()
+
+    def on_before_optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
+        self.model.loss.assert_accumulation_cache_idle()
+        super().on_before_optimizer_step(optimizer)
+
+    def on_validation_epoch_start(self) -> None:
+        self.model.loss.assert_accumulation_cache_idle()
+        super().on_validation_epoch_start()
+
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        self.model.loss.assert_accumulation_cache_idle()
+        super().on_save_checkpoint(checkpoint)

--- a/replay/nn/lightning/catalog_cache.py
+++ b/replay/nn/lightning/catalog_cache.py
@@ -6,7 +6,26 @@ from replay.nn.lightning.module import LightningModule
 
 
 class CatalogCacheLightningModule(LightningModule):
-    """Lightning wrapper for a loss that caches the item catalog across accumulation."""
+    """Lightning wrapper for a loss that caches the item catalog across accumulation.
+
+    The wrapper supports Lightning automatic optimization when the strategy
+    leaves gradient accumulation to the training loop, including DDP.
+    """
+
+    _LOSS_METHODS = (
+        "prepare_accumulation_microbatch",
+        "should_retain_graph_for_current_backward",
+        "assert_current_backward_completed",
+        "assert_accumulation_cache_idle",
+    )
+
+    def _catalog_cache_loss(self) -> torch.nn.Module:
+        loss = getattr(self.model, "loss", None)
+        missing = tuple(name for name in self._LOSS_METHODS if not callable(getattr(loss, name, None)))
+        if missing:
+            msg = f"CatalogCacheLightningModule requires a catalog-cache loss; missing methods: {missing}."
+            raise TypeError(msg)
+        return loss
 
     def _is_accumulation_window_end(self, batch_idx: int) -> bool:
         accumulation_steps = self.trainer.accumulate_grad_batches
@@ -15,7 +34,7 @@ class CatalogCacheLightningModule(LightningModule):
 
     def training_step(self, batch: dict, batch_idx: int) -> torch.Tensor:
         accumulation_steps = self.trainer.accumulate_grad_batches
-        self.model.loss.prepare_accumulation_microbatch(
+        self._catalog_cache_loss().prepare_accumulation_microbatch(
             is_window_end=self._is_accumulation_window_end(batch_idx),
             trainer_accumulation_steps=accumulation_steps,
             global_step=self.global_step,
@@ -26,29 +45,39 @@ class CatalogCacheLightningModule(LightningModule):
         if "retain_graph" in kwargs:
             msg = "CatalogCacheLightningModule controls retain_graph during accumulation."
             raise ValueError(msg)
-        kwargs["retain_graph"] = self.model.loss.should_retain_graph_for_current_backward()
+        kwargs["retain_graph"] = self._catalog_cache_loss().should_retain_graph_for_current_backward()
         super().backward(loss, *args, **kwargs)
 
     def on_after_backward(self) -> None:
-        self.model.loss.assert_current_backward_completed()
+        self._catalog_cache_loss().assert_current_backward_completed()
         super().on_after_backward()
 
     def on_train_epoch_start(self) -> None:
-        self.model.loss.assert_accumulation_cache_idle()
+        self._catalog_cache_loss().assert_accumulation_cache_idle()
         super().on_train_epoch_start()
 
     def on_train_epoch_end(self) -> None:
-        self.model.loss.assert_accumulation_cache_idle()
+        self._catalog_cache_loss().assert_accumulation_cache_idle()
         super().on_train_epoch_end()
 
     def on_before_optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
-        self.model.loss.assert_accumulation_cache_idle()
+        self._catalog_cache_loss().assert_accumulation_cache_idle()
         super().on_before_optimizer_step(optimizer)
 
     def on_validation_epoch_start(self) -> None:
-        self.model.loss.assert_accumulation_cache_idle()
+        self._catalog_cache_loss().assert_accumulation_cache_idle()
         super().on_validation_epoch_start()
 
     def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
-        self.model.loss.assert_accumulation_cache_idle()
+        self._catalog_cache_loss().assert_accumulation_cache_idle()
         super().on_save_checkpoint(checkpoint)
+
+    def on_train_start(self) -> None:
+        self._catalog_cache_loss()
+        if not self.automatic_optimization:
+            msg = "CatalogCacheLightningModule requires automatic optimization."
+            raise RuntimeError(msg)
+        if self.trainer.strategy.handles_gradient_accumulation:
+            msg = "The selected Lightning strategy handles gradient accumulation internally."
+            raise RuntimeError(msg)
+        super().on_train_start()

--- a/replay/nn/loss/__init__.py
+++ b/replay/nn/loss/__init__.py
@@ -1,6 +1,7 @@
 from .base import LossProto
 from .bce import BCE, BCESampled
 from .ce import CE, CESampled, CESampledWeighted, CEWeighted
+from .grouped_ce import CatalogCachedGroupedCESampled, GroupedCESampled
 from .login_ce import LogInCE, LogInCESampled
 from .logout_ce import LogOutCE, LogOutCEWeighted
 
@@ -13,6 +14,8 @@ __all__ = [
     "CESampled",
     "CESampledWeighted",
     "CEWeighted",
+    "CatalogCachedGroupedCESampled",
+    "GroupedCESampled",
     "LogInCE",
     "LogInCESampled",
     "LogOutCE",

--- a/replay/nn/loss/grouped_ce.py
+++ b/replay/nn/loss/grouped_ce.py
@@ -1,0 +1,444 @@
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as functional
+
+from replay.data.nn import TensorMap
+from replay.nn.head import EmbeddingTyingHead
+from replay.nn.loss.base import mask_negative_logits
+from replay.nn.loss.ce import CESampled
+from replay.nn.sequential.twotower import TwoTower
+
+
+class GroupedCESampled(CESampled):
+    """Sampled CE with one independent negative pool per logical batch group.
+
+    Group losses are divided by ``groups_per_batch`` even for the final short
+    batch. This preserves the weighting of the original smaller batches when
+    the physical batch size is increased together with gradient accumulation.
+    """
+
+    def __init__(
+        self,
+        logical_batch_size: int,
+        groups_per_batch: int,
+        expected_num_negatives: int | None = None,
+        negative_labels_ignore_index: int = -100,
+        **kwargs,
+    ) -> None:
+        """
+        :param logical_batch_size: Number of rows that share one negative pool.
+        :param groups_per_batch: Number of logical groups in a full physical batch.
+        :param expected_num_negatives: Optional required size of every negative pool.
+        :param negative_labels_ignore_index: Value ignored in negative labels.
+        :param kwargs: Arguments passed to :class:`torch.nn.CrossEntropyLoss`.
+        """
+        if logical_batch_size <= 0:
+            msg = "The logical_batch_size parameter must be positive."
+            raise ValueError(msg)
+        if groups_per_batch <= 1:
+            msg = "The groups_per_batch parameter must be greater than one."
+            raise ValueError(msg)
+        if expected_num_negatives is not None and expected_num_negatives <= 0:
+            msg = "The expected_num_negatives parameter must be positive."
+            raise ValueError(msg)
+        super().__init__(negative_labels_ignore_index=negative_labels_ignore_index, **kwargs)
+        if self._loss.reduction != "mean":
+            msg = "GroupedCESampled supports only mean reduction."
+            raise ValueError(msg)
+        self.logical_batch_size = logical_batch_size
+        self.groups_per_batch = groups_per_batch
+        self.expected_num_negatives = expected_num_negatives
+
+    def _validate_inputs(
+        self,
+        model_embeddings: torch.Tensor,
+        positive_labels: torch.LongTensor,
+        negative_labels: torch.LongTensor,
+        target_padding_mask: torch.BoolTensor,
+    ) -> int:
+        if model_embeddings.dim() != 3:
+            msg = "model_embeddings must have shape [batch, sequence, embedding]."
+            raise ValueError(msg)
+        if positive_labels.dim() != 3 or positive_labels.size(-1) != 1:
+            msg = "GroupedCESampled requires exactly one positive label per sequence position."
+            raise ValueError(msg)
+        if positive_labels.shape[:2] != model_embeddings.shape[:2]:
+            msg = "positive_labels and model_embeddings must have equal batch and sequence dimensions."
+            raise ValueError(msg)
+        if target_padding_mask.shape != positive_labels.shape:
+            msg = "target_padding_mask must have the same shape as positive_labels."
+            raise ValueError(msg)
+        if negative_labels.dim() != 2 or negative_labels.size(0) != self.groups_per_batch:
+            msg = f"negative_labels must have shape [{self.groups_per_batch}, num_negatives]."
+            raise ValueError(msg)
+        if self.expected_num_negatives is not None and negative_labels.size(1) != self.expected_num_negatives:
+            msg = f"Each negative pool must contain {self.expected_num_negatives} items, got {negative_labels.size(1)}."
+            raise ValueError(msg)
+        if model_embeddings.size(0) == 0:
+            msg = "GroupedCESampled does not support empty batches."
+            raise ValueError(msg)
+
+        active_groups = (model_embeddings.size(0) + self.logical_batch_size - 1) // self.logical_batch_size
+        if active_groups > self.groups_per_batch:
+            capacity = self.logical_batch_size * self.groups_per_batch
+            msg = f"Batch size {model_embeddings.size(0)} exceeds grouped loss capacity {capacity}."
+            raise ValueError(msg)
+        return active_groups
+
+    def _loss_from_logits(
+        self,
+        positive_logits: torch.Tensor,
+        negative_logits: torch.Tensor,
+        positive_labels: torch.LongTensor,
+        negative_labels: torch.LongTensor,
+    ) -> torch.Tensor:
+        negative_logits = mask_negative_logits(
+            negative_logits,
+            negative_labels,
+            positive_labels.unsqueeze(-1),
+            self.negative_labels_ignore_index,
+        )
+        logits = torch.cat((positive_logits, negative_logits), dim=-1)
+        target = torch.zeros(positive_logits.size(0), dtype=torch.long, device=logits.device)
+        return self._loss(logits, target)
+
+    def _score_group(
+        self,
+        model_embeddings: torch.Tensor,
+        positive_labels: torch.LongTensor,
+        negative_labels: torch.LongTensor,
+    ) -> torch.Tensor:
+        positive_logits = self.logits_callback(model_embeddings, positive_labels.unsqueeze(-1))
+        negative_logits = self.logits_callback(model_embeddings, negative_labels)
+        return self._loss_from_logits(
+            positive_logits,
+            negative_logits,
+            positive_labels,
+            negative_labels,
+        )
+
+    def forward(
+        self,
+        model_embeddings: torch.Tensor,
+        feature_tensors: TensorMap,  # noqa: ARG002
+        positive_labels: torch.LongTensor,
+        negative_labels: torch.LongTensor,
+        padding_mask: torch.BoolTensor,  # noqa: ARG002
+        target_padding_mask: torch.BoolTensor,
+    ) -> torch.Tensor:
+        active_groups = self._validate_inputs(
+            model_embeddings,
+            positive_labels,
+            negative_labels,
+            target_padding_mask,
+        )
+        loss = model_embeddings.new_zeros(())
+        for group_index in range(active_groups):
+            start = group_index * self.logical_batch_size
+            end = min(start + self.logical_batch_size, model_embeddings.size(0))
+            active_targets = target_padding_mask[start:end].squeeze(-1)
+            group_embeddings = model_embeddings[start:end][active_targets]
+            group_positive_labels = positive_labels[start:end].squeeze(-1)[active_targets]
+            if group_embeddings.size(0) == 0:
+                msg = "Each active logical group must contain at least one target."
+                raise ValueError(msg)
+            loss = loss + self._score_group(
+                group_embeddings,
+                group_positive_labels,
+                negative_labels[group_index],
+            )
+        return loss / self.groups_per_batch
+
+
+class _CatalogGradientState:
+    def __init__(self, accumulation_steps: int) -> None:
+        if accumulation_steps <= 1:
+            msg = "The accumulation_steps parameter must be greater than one."
+            raise ValueError(msg)
+        self.accumulation_steps = accumulation_steps
+        self.catalog_embeddings: torch.Tensor | None = None
+        self.pending_gradient: torch.Tensor | None = None
+        self.prepared_window_end: bool | None = None
+        self.retain_graph: bool | None = None
+        self.window_global_step: int | None = None
+        self.microbatch_count = 0
+
+    def prepare(
+        self,
+        *,
+        is_window_end: bool,
+        trainer_accumulation_steps: int,
+        global_step: int,
+    ) -> None:
+        if trainer_accumulation_steps != self.accumulation_steps:
+            msg = (
+                f"The loss expects {self.accumulation_steps} accumulation steps, "
+                f"but the trainer uses {trainer_accumulation_steps}."
+            )
+            raise ValueError(msg)
+        if self.prepared_window_end is not None:
+            msg = "The previously prepared catalog-cache microbatch was not consumed."
+            raise RuntimeError(msg)
+        if self.window_global_step is not None and self.window_global_step != global_step:
+            msg = "global_step changed inside a catalog-cache accumulation window."
+            raise RuntimeError(msg)
+        next_microbatch_count = self.microbatch_count + 1
+        if next_microbatch_count > self.accumulation_steps:
+            msg = "The catalog-cache accumulation window did not finish on time."
+            raise RuntimeError(msg)
+        if next_microbatch_count == self.accumulation_steps and not is_window_end:
+            msg = "The catalog-cache window must end after accumulation_steps microbatches."
+            raise RuntimeError(msg)
+        if self.window_global_step is None:
+            self.window_global_step = global_step
+        self.microbatch_count = next_microbatch_count
+        self.prepared_window_end = is_window_end
+
+    def consume(self) -> bool:
+        if self.prepared_window_end is None:
+            msg = "Call prepare_accumulation_microbatch before the catalog-cache loss."
+            raise RuntimeError(msg)
+        is_window_end = self.prepared_window_end
+        self.prepared_window_end = None
+        self.retain_graph = not is_window_end
+        return is_window_end
+
+    def accumulate_gradient(
+        self,
+        gradient: torch.Tensor,
+        *,
+        is_window_end: bool,
+    ) -> torch.Tensor | None:
+        gradient = gradient.detach()
+        self.retain_graph = None
+        if self.pending_gradient is None:
+            accumulated = gradient.clone()
+        else:
+            if self.pending_gradient.shape != gradient.shape:
+                msg = "Catalog gradients changed shape inside an accumulation window."
+                raise RuntimeError(msg)
+            self.pending_gradient.add_(gradient)
+            accumulated = self.pending_gradient
+        if not is_window_end:
+            self.pending_gradient = accumulated
+            return None
+
+        self.catalog_embeddings = None
+        self.pending_gradient = None
+        self.window_global_step = None
+        self.microbatch_count = 0
+        return accumulated
+
+    def should_retain_graph(self) -> bool:
+        if self.retain_graph is None:
+            msg = "The catalog-cache forward pass did not prepare backward."
+            raise RuntimeError(msg)
+        return self.retain_graph
+
+    def assert_backward_completed(self) -> None:
+        if self.prepared_window_end is not None or self.retain_graph is not None:
+            msg = "The catalog-cache forward pass did not complete exactly one backward pass."
+            raise RuntimeError(msg)
+
+    def assert_idle(self) -> None:
+        if (
+            any(
+                value is not None
+                for value in (
+                    self.catalog_embeddings,
+                    self.pending_gradient,
+                    self.prepared_window_end,
+                    self.retain_graph,
+                    self.window_global_step,
+                )
+            )
+            or self.microbatch_count != 0
+        ):
+            msg = "The catalog-cache accumulation state is not idle."
+            raise RuntimeError(msg)
+
+
+class _DeferredCatalogGradient(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx: object,
+        catalog_embeddings: torch.Tensor,
+        state: _CatalogGradientState,
+        is_window_end: bool,
+    ) -> torch.Tensor:
+        ctx.state = state
+        ctx.is_window_end = is_window_end
+        return catalog_embeddings.view_as(catalog_embeddings)
+
+    @staticmethod
+    def backward(
+        ctx: object,
+        gradient: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, None, None]:
+        return (
+            ctx.state.accumulate_gradient(gradient, is_window_end=ctx.is_window_end),
+            None,
+            None,
+        )
+
+
+class CatalogCachedGroupedCESampled(GroupedCESampled):
+    """Reuse one item-catalog graph across a gradient-accumulation window.
+
+    The item tower must be deterministic and candidate-separable. The cache is
+    differentiable: gradients from all microbatches reach the item tower once,
+    at the optimizer-step boundary.
+    """
+
+    def __init__(
+        self,
+        cardinality: int,
+        logical_batch_size: int,
+        groups_per_batch: int,
+        accumulation_steps: int,
+        negative_labels_ignore_index: int = -100,
+        **kwargs,
+    ) -> None:
+        """
+        :param cardinality: Number of items returned by the item tower for the full catalog.
+        :param logical_batch_size: Number of rows that share one negative pool.
+        :param groups_per_batch: Number of logical groups in a full physical batch.
+        :param accumulation_steps: Number of physical batches in one optimizer step.
+        :param negative_labels_ignore_index: Value ignored in negative labels.
+        :param kwargs: Arguments passed to :class:`torch.nn.CrossEntropyLoss`.
+        """
+        if cardinality <= 0:
+            msg = "The cardinality parameter must be positive."
+            raise ValueError(msg)
+        super().__init__(
+            logical_batch_size=logical_batch_size,
+            groups_per_batch=groups_per_batch,
+            negative_labels_ignore_index=negative_labels_ignore_index,
+            **kwargs,
+        )
+        self.cardinality = cardinality
+        self._catalog_state = _CatalogGradientState(accumulation_steps)
+
+    def prepare_accumulation_microbatch(
+        self,
+        *,
+        is_window_end: bool,
+        trainer_accumulation_steps: int,
+        global_step: int,
+    ) -> None:
+        self._catalog_state.prepare(
+            is_window_end=is_window_end,
+            trainer_accumulation_steps=trainer_accumulation_steps,
+            global_step=global_step,
+        )
+
+    def should_retain_graph_for_current_backward(self) -> bool:
+        return self._catalog_state.should_retain_graph()
+
+    def assert_current_backward_completed(self) -> None:
+        self._catalog_state.assert_backward_completed()
+
+    def assert_accumulation_cache_idle(self) -> None:
+        self._catalog_state.assert_idle()
+
+    def _resolve_model_parts(self) -> tuple[torch.nn.Module, EmbeddingTyingHead]:
+        callback: Callable = self.logits_callback
+        owner = getattr(callback, "__self__", None)
+        function = getattr(callback, "__func__", None)
+        item_tower = getattr(getattr(owner, "body", None), "item_tower", None)
+        head = getattr(owner, "head", None)
+        if function is not TwoTower.get_logits or not isinstance(item_tower, torch.nn.Module):
+            msg = "CatalogCachedGroupedCESampled requires a bound TwoTower.get_logits callback."
+            raise TypeError(msg)
+        if type(head) is not EmbeddingTyingHead:
+            msg = "CatalogCachedGroupedCESampled supports the standard EmbeddingTyingHead only."
+            raise TypeError(msg)
+        return item_tower, head
+
+    @staticmethod
+    def _validate_item_tower(item_tower: torch.nn.Module) -> None:
+        stochastic_modules = (
+            torch.nn.AlphaDropout,
+            torch.nn.BatchNorm1d,
+            torch.nn.BatchNorm2d,
+            torch.nn.BatchNorm3d,
+            torch.nn.Dropout,
+            torch.nn.Dropout1d,
+            torch.nn.Dropout2d,
+            torch.nn.Dropout3d,
+            torch.nn.FeatureAlphaDropout,
+            torch.nn.SyncBatchNorm,
+        )
+        unsupported = tuple(
+            module.__class__.__name__ for module in item_tower.modules() if isinstance(module, stochastic_modules)
+        )
+        if unsupported:
+            msg = f"The cached item tower must be deterministic and candidate-separable; found {unsupported}."
+            raise TypeError(msg)
+
+    def _get_catalog(self, item_tower: torch.nn.Module, device: torch.device) -> torch.Tensor:
+        catalog = self._catalog_state.catalog_embeddings
+        if catalog is None:
+            self._validate_item_tower(item_tower)
+            catalog = item_tower()
+            if catalog.dim() != 2 or catalog.size(0) != self.cardinality:
+                msg = f"The item tower must return a two-dimensional full catalog with {self.cardinality} rows."
+                raise RuntimeError(msg)
+            if catalog.device != device:
+                msg = "The item catalog and model embeddings must be on the same device."
+                raise RuntimeError(msg)
+            self._catalog_state.catalog_embeddings = catalog
+        elif catalog.device != device:
+            msg = "The catalog cache changed device inside an accumulation window."
+            raise RuntimeError(msg)
+        return catalog
+
+    def forward(
+        self,
+        model_embeddings: torch.Tensor,
+        feature_tensors: TensorMap,  # noqa: ARG002
+        positive_labels: torch.LongTensor,
+        negative_labels: torch.LongTensor,
+        padding_mask: torch.BoolTensor,  # noqa: ARG002
+        target_padding_mask: torch.BoolTensor,
+    ) -> torch.Tensor:
+        active_groups = self._validate_inputs(
+            model_embeddings,
+            positive_labels,
+            negative_labels,
+            target_padding_mask,
+        )
+        is_window_end = self._catalog_state.consume()
+        item_tower, _ = self._resolve_model_parts()
+        catalog = self._get_catalog(item_tower, model_embeddings.device)
+        catalog = _DeferredCatalogGradient.apply(catalog, self._catalog_state, is_window_end)
+
+        loss = model_embeddings.new_zeros(())
+        for group_index in range(active_groups):
+            start = group_index * self.logical_batch_size
+            end = min(start + self.logical_batch_size, model_embeddings.size(0))
+            active_targets = target_padding_mask[start:end].squeeze(-1)
+            group_embeddings = model_embeddings[start:end][active_targets]
+            group_positive_labels = positive_labels[start:end].squeeze(-1)[active_targets]
+            if group_embeddings.size(0) == 0:
+                msg = "Each active logical group must contain at least one target."
+                raise ValueError(msg)
+
+            group_negative_labels = negative_labels[group_index]
+            scoring_negative_labels = group_negative_labels.masked_fill(
+                group_negative_labels.eq(self.negative_labels_ignore_index),
+                0,
+            )
+            positive_logits = (group_embeddings * catalog[group_positive_labels]).sum(
+                dim=-1,
+                keepdim=True,
+            )
+            negative_logits = functional.linear(group_embeddings, catalog[scoring_negative_labels])
+            loss = loss + self._loss_from_logits(
+                positive_logits,
+                negative_logits,
+                group_positive_labels,
+                group_negative_labels,
+            )
+        return loss / self.groups_per_batch

--- a/replay/nn/loss/grouped_ce.py
+++ b/replay/nn/loss/grouped_ce.py
@@ -13,7 +13,8 @@ from replay.nn.sequential.twotower import TwoTower
 class GroupedCESampled(CESampled):
     """Sampled CE with one independent negative pool per logical batch group.
 
-    Group losses are divided by ``groups_per_batch`` even for the final short
+    Negative pools must contain unique item IDs. Group losses are divided by
+    ``groups_per_batch`` even for the final short
     batch. This preserves the weighting of the original smaller batches when
     the physical batch size is increased together with gradient accumulation.
     """
@@ -23,6 +24,7 @@ class GroupedCESampled(CESampled):
         logical_batch_size: int,
         groups_per_batch: int,
         expected_num_negatives: int | None = None,
+        cardinality: int | None = None,
         negative_labels_ignore_index: int = -100,
         **kwargs,
     ) -> None:
@@ -30,6 +32,8 @@ class GroupedCESampled(CESampled):
         :param logical_batch_size: Number of rows that share one negative pool.
         :param groups_per_batch: Number of logical groups in a full physical batch.
         :param expected_num_negatives: Optional required size of every negative pool.
+        :param cardinality: Optional catalog size enabling collision masking without a
+            target-by-negative comparison matrix.
         :param negative_labels_ignore_index: Value ignored in negative labels.
         :param kwargs: Arguments passed to :class:`torch.nn.CrossEntropyLoss`.
         """
@@ -42,6 +46,9 @@ class GroupedCESampled(CESampled):
         if expected_num_negatives is not None and expected_num_negatives <= 0:
             msg = "The expected_num_negatives parameter must be positive."
             raise ValueError(msg)
+        if cardinality is not None and cardinality <= 0:
+            msg = "The cardinality parameter must be positive."
+            raise ValueError(msg)
         super().__init__(negative_labels_ignore_index=negative_labels_ignore_index, **kwargs)
         if self._loss.reduction != "mean":
             msg = "GroupedCESampled supports only mean reduction."
@@ -49,6 +56,8 @@ class GroupedCESampled(CESampled):
         self.logical_batch_size = logical_batch_size
         self.groups_per_batch = groups_per_batch
         self.expected_num_negatives = expected_num_negatives
+        self.cardinality = cardinality
+        self.register_buffer("_negative_column_lookup", None, persistent=False)
 
     def _validate_inputs(
         self,
@@ -93,15 +102,47 @@ class GroupedCESampled(CESampled):
         positive_labels: torch.LongTensor,
         negative_labels: torch.LongTensor,
     ) -> torch.Tensor:
-        negative_logits = mask_negative_logits(
-            negative_logits,
-            negative_labels,
-            positive_labels.unsqueeze(-1),
-            self.negative_labels_ignore_index,
-        )
+        negative_logits = self._mask_negative_logits(negative_logits, negative_labels, positive_labels)
         logits = torch.cat((positive_logits, negative_logits), dim=-1)
         target = torch.zeros(positive_logits.size(0), dtype=torch.long, device=logits.device)
         return self._loss(logits, target)
+
+    def _mask_negative_logits(
+        self,
+        negative_logits: torch.Tensor,
+        negative_labels: torch.LongTensor,
+        positive_labels: torch.LongTensor,
+    ) -> torch.Tensor:
+        if self.cardinality is None:
+            return mask_negative_logits(
+                negative_logits,
+                negative_labels,
+                positive_labels.unsqueeze(-1),
+                self.negative_labels_ignore_index,
+            )
+
+        lookup = self._negative_column_lookup
+        if lookup is None or lookup.device != negative_labels.device:
+            lookup = torch.empty(self.cardinality, dtype=torch.int32, device=negative_labels.device)
+            self._negative_column_lookup = lookup
+        lookup.fill_(-1)
+
+        valid_negatives = negative_labels.ge(0) & negative_labels.lt(self.cardinality)
+        negative_columns = torch.arange(negative_labels.numel(), dtype=lookup.dtype, device=negative_labels.device)
+        lookup[negative_labels[valid_negatives]] = negative_columns[valid_negatives]
+
+        valid_positives = positive_labels.ge(0) & positive_labels.lt(self.cardinality)
+        safe_positives = positive_labels.clamp(min=0, max=self.cardinality - 1)
+        collision_columns = lookup[safe_positives].long()
+        collision_rows = torch.arange(positive_labels.numel(), device=positive_labels.device)
+        collisions = valid_positives & collision_columns.ge(0)
+        masked_value = max(-1e9, torch.finfo(negative_logits.dtype).min)
+        negative_logits.masked_fill_(
+            negative_labels.eq(self.negative_labels_ignore_index).unsqueeze(0),
+            masked_value,
+        )
+        negative_logits[collision_rows[collisions], collision_columns[collisions]] = masked_value
+        return negative_logits
 
     def _score_group(
         self,
@@ -110,7 +151,11 @@ class GroupedCESampled(CESampled):
         negative_labels: torch.LongTensor,
     ) -> torch.Tensor:
         positive_logits = self.logits_callback(model_embeddings, positive_labels.unsqueeze(-1))
-        negative_logits = self.logits_callback(model_embeddings, negative_labels)
+        scoring_negative_labels = negative_labels.masked_fill(
+            negative_labels.eq(self.negative_labels_ignore_index),
+            0,
+        )
+        negative_logits = self.logits_callback(model_embeddings, scoring_negative_labels)
         return self._loss_from_logits(
             positive_logits,
             negative_logits,
@@ -314,6 +359,7 @@ class CatalogCachedGroupedCESampled(GroupedCESampled):
         super().__init__(
             logical_batch_size=logical_batch_size,
             groups_per_batch=groups_per_batch,
+            cardinality=cardinality,
             negative_labels_ignore_index=negative_labels_ignore_index,
             **kwargs,
         )

--- a/replay/nn/transform/__init__.py
+++ b/replay/nn/transform/__init__.py
@@ -1,7 +1,11 @@
 from .copy import CopyTransform
 from .equality_mask import EqualityMaskTransform
 from .grouping import GroupTransform
-from .negative_sampling import MultiClassNegativeSamplingTransform, UniformNegativeSamplingTransform
+from .negative_sampling import (
+    GroupedUniformNegativeSamplingTransform,
+    MultiClassNegativeSamplingTransform,
+    UniformNegativeSamplingTransform,
+)
 from .next_token import NextTokenTransform
 from .rename import RenameTransform
 from .reshape import UnsqueezeTransform
@@ -15,6 +19,7 @@ __all__ = [
     "CopyTransform",
     "EqualityMaskTransform",
     "GroupTransform",
+    "GroupedUniformNegativeSamplingTransform",
     "MultiClassNegativeSamplingTransform",
     "NextTokenTransform",
     "RenameTransform",

--- a/replay/nn/transform/negative_sampling.py
+++ b/replay/nn/transform/negative_sampling.py
@@ -79,6 +79,89 @@ class UniformNegativeSamplingTransform(torch.nn.Module):
         return output_batch
 
 
+class GroupedUniformNegativeSamplingTransform(UniformNegativeSamplingTransform):
+    """Draw an independent negative pool for each logical batch group.
+
+    This transform allows several logical batches to be packed into one larger
+    physical batch without changing how often negatives are sampled.
+    """
+
+    def __init__(
+        self,
+        cardinality: int,
+        num_negative_samples: int,
+        group_size: int,
+        groups_per_batch: int,
+        *,
+        batch_feature_name: str = "positive_labels",
+        out_feature_name: str = "negative_labels",
+        sample_distribution: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> None:
+        """
+        :param cardinality: Number of items in the catalog, excluding padding.
+        :param num_negative_samples: Number of items in each negative pool.
+        :param group_size: Number of rows in one logical batch group.
+        :param groups_per_batch: Number of logical groups in a full physical batch.
+        :param batch_feature_name: Feature whose first dimension defines the physical batch size.
+        :param out_feature_name: Name of the generated grouped negative tensor.
+        :param sample_distribution: Optional sampling weights of length ``cardinality``.
+        :param generator: Optional random number generator.
+        """
+        if group_size <= 0:
+            msg = "The group_size parameter must be positive."
+            raise ValueError(msg)
+        if groups_per_batch <= 1:
+            msg = "The groups_per_batch parameter must be greater than one."
+            raise ValueError(msg)
+        super().__init__(
+            cardinality=cardinality,
+            num_negative_samples=num_negative_samples,
+            out_feature_name=out_feature_name,
+            sample_distribution=sample_distribution,
+            generator=generator,
+        )
+        self.group_size = group_size
+        self.groups_per_batch = groups_per_batch
+        self.batch_feature_name = batch_feature_name
+
+    def forward(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        if self.batch_feature_name not in batch:
+            msg = f"The batch does not contain {self.batch_feature_name!r}."
+            raise ValueError(msg)
+        batch_feature = batch[self.batch_feature_name]
+        if batch_feature.dim() == 0 or batch_feature.size(0) == 0:
+            msg = f"The {self.batch_feature_name!r} feature must have a non-empty batch dimension."
+            raise ValueError(msg)
+
+        active_groups = (batch_feature.size(0) + self.group_size - 1) // self.group_size
+        if active_groups > self.groups_per_batch:
+            capacity = self.group_size * self.groups_per_batch
+            msg = f"Batch size {batch_feature.size(0)} exceeds grouped sampler capacity {capacity}."
+            raise ValueError(msg)
+
+        pools = torch.stack(
+            [
+                torch.multinomial(
+                    self.sample_distribution,
+                    num_samples=self.num_negative_samples,
+                    replacement=False,
+                    generator=self.generator,
+                )
+                for _ in range(active_groups)
+            ]
+        )
+        if active_groups < self.groups_per_batch:
+            pools = torch.cat(
+                (pools, pools[-1:].expand(self.groups_per_batch - active_groups, -1)),
+                dim=0,
+            )
+
+        output_batch = dict(batch.items())
+        output_batch[self.out_feature_name] = pools
+        return output_batch
+
+
 class MultiClassNegativeSamplingTransform(torch.nn.Module):
     """
     Transform for generating negatives using a fixed class-assignment matrix.

--- a/tests/nn/lightning/test_catalog_cache.py
+++ b/tests/nn/lightning/test_catalog_cache.py
@@ -1,9 +1,44 @@
 from types import SimpleNamespace
 
+import lightning
 import pytest
 import torch
+from torch.utils.data import DataLoader
 
 from replay.nn.lightning import CatalogCacheLightningModule
+from replay.nn.lightning.optimizer import OptimizerFactory
+from replay.nn.loss import CatalogCachedGroupedCESampled
+from replay.nn.sequential.twotower import TwoTower
+
+
+class _ItemTower(torch.nn.Module):
+    def __init__(self, cardinality: int, embedding_dim: int) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(cardinality, embedding_dim))
+        self.forward_calls = 0
+
+    def forward(self, candidates: torch.LongTensor | None = None) -> torch.Tensor:
+        self.forward_calls += 1
+        return self.weight if candidates is None else self.weight[candidates]
+
+
+class _QueryTower(torch.nn.Module):
+    def __init__(self, embedding_dim: int) -> None:
+        super().__init__()
+        self.projection = torch.nn.Linear(embedding_dim, embedding_dim, bias=False)
+
+    def forward(self, feature_tensors, padding_mask):
+        return self.projection(feature_tensors["query"])
+
+
+class _Body(torch.nn.Module):
+    def __init__(self, cardinality: int, embedding_dim: int) -> None:
+        super().__init__()
+        self.query_tower = _QueryTower(embedding_dim)
+        self.item_tower = _ItemTower(cardinality, embedding_dim)
+
+    def reset_parameters(self) -> None:
+        pass
 
 
 def test_accumulation_window_end_includes_short_final_window():
@@ -22,3 +57,47 @@ def test_catalog_cache_module_rejects_model_without_cache_loss():
 
     with pytest.raises(TypeError, match="missing methods"):
         module._catalog_cache_loss()
+
+
+def test_catalog_cache_runs_complete_lightning_accumulation_window():
+    cardinality, embedding_dim = 20, 8
+    loss = CatalogCachedGroupedCESampled(
+        cardinality=cardinality,
+        logical_batch_size=2,
+        groups_per_batch=2,
+        expected_num_negatives=7,
+        accumulation_steps=3,
+    )
+    model = TwoTower(_Body(cardinality, embedding_dim), loss)
+    rows = [
+        {
+            "feature_tensors": {"query": torch.randn(3, embedding_dim)},
+            "padding_mask": torch.ones(3, dtype=torch.bool),
+            "positive_labels": torch.randint(0, cardinality, (3, 1)),
+            "target_padding_mask": torch.ones(3, 1, dtype=torch.bool),
+        }
+        for _ in range(10)
+    ]
+
+    def collate(batch):
+        result = torch.utils.data.default_collate(batch)
+        result["negative_labels"] = torch.stack([torch.randperm(cardinality)[:7] for _ in range(2)])
+        return result
+
+    module = CatalogCacheLightningModule(
+        model,
+        optimizer_factory=OptimizerFactory(optimizer="sgd", learning_rate=0.01),
+    )
+    trainer = lightning.Trainer(
+        max_epochs=1,
+        accumulate_grad_batches=3,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+
+    trainer.fit(module, train_dataloaders=DataLoader(rows, batch_size=4, collate_fn=collate))
+
+    model.loss.assert_accumulation_cache_idle()
+    assert model.body.item_tower.forward_calls == 1

--- a/tests/nn/lightning/test_catalog_cache.py
+++ b/tests/nn/lightning/test_catalog_cache.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from replay.nn.lightning import CatalogCacheLightningModule
@@ -14,3 +15,10 @@ def test_accumulation_window_end_includes_short_final_window():
     assert module._is_accumulation_window_end(2)
     assert not module._is_accumulation_window_end(3)
     assert module._is_accumulation_window_end(4)
+
+
+def test_catalog_cache_module_rejects_model_without_cache_loss():
+    module = CatalogCacheLightningModule(torch.nn.Linear(2, 2))
+
+    with pytest.raises(TypeError, match="missing methods"):
+        module._catalog_cache_loss()

--- a/tests/nn/lightning/test_catalog_cache.py
+++ b/tests/nn/lightning/test_catalog_cache.py
@@ -1,3 +1,4 @@
+from functools import partial
 from types import SimpleNamespace
 
 import lightning
@@ -41,6 +42,24 @@ class _Body(torch.nn.Module):
         pass
 
 
+def _catalog_rows(cardinality: int, embedding_dim: int) -> list[dict]:
+    return [
+        {
+            "feature_tensors": {"query": torch.randn(3, embedding_dim)},
+            "padding_mask": torch.ones(3, dtype=torch.bool),
+            "positive_labels": torch.randint(0, cardinality, (3, 1)),
+            "target_padding_mask": torch.ones(3, 1, dtype=torch.bool),
+        }
+        for _ in range(10)
+    ]
+
+
+def _catalog_collate(batch: list[dict], cardinality: int) -> dict:
+    result = torch.utils.data.default_collate(batch)
+    result["negative_labels"] = torch.stack([torch.randperm(cardinality)[:7] for _ in range(2)])
+    return result
+
+
 def test_accumulation_window_end_includes_short_final_window():
     module = CatalogCacheLightningModule(torch.nn.Linear(2, 2))
     module._trainer = SimpleNamespace(accumulate_grad_batches=3, num_training_batches=5)
@@ -69,21 +88,6 @@ def test_catalog_cache_runs_complete_lightning_accumulation_window():
         accumulation_steps=3,
     )
     model = TwoTower(_Body(cardinality, embedding_dim), loss)
-    rows = [
-        {
-            "feature_tensors": {"query": torch.randn(3, embedding_dim)},
-            "padding_mask": torch.ones(3, dtype=torch.bool),
-            "positive_labels": torch.randint(0, cardinality, (3, 1)),
-            "target_padding_mask": torch.ones(3, 1, dtype=torch.bool),
-        }
-        for _ in range(10)
-    ]
-
-    def collate(batch):
-        result = torch.utils.data.default_collate(batch)
-        result["negative_labels"] = torch.stack([torch.randperm(cardinality)[:7] for _ in range(2)])
-        return result
-
     module = CatalogCacheLightningModule(
         model,
         optimizer_factory=OptimizerFactory(optimizer="sgd", learning_rate=0.01),
@@ -97,7 +101,49 @@ def test_catalog_cache_runs_complete_lightning_accumulation_window():
         enable_progress_bar=False,
     )
 
-    trainer.fit(module, train_dataloaders=DataLoader(rows, batch_size=4, collate_fn=collate))
+    trainer.fit(
+        module,
+        train_dataloaders=DataLoader(
+            _catalog_rows(cardinality, embedding_dim),
+            batch_size=4,
+            collate_fn=partial(_catalog_collate, cardinality=cardinality),
+        ),
+    )
 
     model.loss.assert_accumulation_cache_idle()
     assert model.body.item_tower.forward_calls == 1
+
+
+def test_catalog_cache_runs_with_two_cpu_ddp_processes():
+    cardinality, embedding_dim = 20, 8
+    loss = CatalogCachedGroupedCESampled(
+        cardinality=cardinality,
+        logical_batch_size=2,
+        groups_per_batch=2,
+        expected_num_negatives=7,
+        accumulation_steps=3,
+    )
+    module = CatalogCacheLightningModule(
+        TwoTower(_Body(cardinality, embedding_dim), loss),
+        optimizer_factory=OptimizerFactory(optimizer="sgd", learning_rate=0.01),
+    )
+    trainer = lightning.Trainer(
+        accelerator="cpu",
+        devices=2,
+        strategy="ddp_spawn",
+        max_epochs=1,
+        accumulate_grad_batches=3,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+
+    trainer.fit(
+        module,
+        train_dataloaders=DataLoader(
+            _catalog_rows(cardinality, embedding_dim),
+            batch_size=4,
+            collate_fn=partial(_catalog_collate, cardinality=cardinality),
+        ),
+    )

--- a/tests/nn/lightning/test_catalog_cache.py
+++ b/tests/nn/lightning/test_catalog_cache.py
@@ -1,0 +1,16 @@
+from types import SimpleNamespace
+
+import torch
+
+from replay.nn.lightning import CatalogCacheLightningModule
+
+
+def test_accumulation_window_end_includes_short_final_window():
+    module = CatalogCacheLightningModule(torch.nn.Linear(2, 2))
+    module._trainer = SimpleNamespace(accumulate_grad_batches=3, num_training_batches=5)
+
+    assert not module._is_accumulation_window_end(0)
+    assert not module._is_accumulation_window_end(1)
+    assert module._is_accumulation_window_end(2)
+    assert not module._is_accumulation_window_end(3)
+    assert module._is_accumulation_window_end(4)

--- a/tests/nn/loss/test_grouped_ce.py
+++ b/tests/nn/loss/test_grouped_ce.py
@@ -156,3 +156,31 @@ def test_grouped_loss_validates_negative_pool_size():
 
     with pytest.raises(ValueError, match="must contain 8"):
         _loss(model, _batch(0))
+
+
+def test_grouped_loss_ignores_padded_negatives_before_item_lookup():
+    model = _make_model(
+        GroupedCESampled(
+            logical_batch_size=2,
+            groups_per_batch=2,
+            negative_labels_ignore_index=-100,
+        )
+    )
+    batch = list(_batch(0))
+    batch[2][:, -1] = -100
+
+    loss = _loss(model, tuple(batch))
+
+    assert torch.isfinite(loss)
+
+
+def test_grouped_loss_fast_collision_mask_matches_generic_path():
+    generic_model = _make_model(GroupedCESampled(logical_batch_size=2, groups_per_batch=2))
+    fast_model = _make_model(GroupedCESampled(logical_batch_size=2, groups_per_batch=2, cardinality=20))
+    fast_model.load_state_dict(copy.deepcopy(generic_model.state_dict()))
+    batch = _batch(3)
+
+    generic_loss = _loss(generic_model, batch)
+    fast_loss = _loss(fast_model, batch)
+
+    torch.testing.assert_close(fast_loss, generic_loss)

--- a/tests/nn/loss/test_grouped_ce.py
+++ b/tests/nn/loss/test_grouped_ce.py
@@ -1,0 +1,158 @@
+import copy
+
+import pytest
+import torch
+
+from replay.nn.loss import CatalogCachedGroupedCESampled, GroupedCESampled
+from replay.nn.sequential.twotower import TwoTower
+
+
+class _ItemTower(torch.nn.Module):
+    def __init__(self, cardinality: int, embedding_dim: int) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(cardinality, embedding_dim))
+        self.forward_calls = 0
+
+    def forward(self, candidates: torch.LongTensor | None = None) -> torch.Tensor:
+        self.forward_calls += 1
+        if candidates is None:
+            return self.weight
+        return self.weight[candidates]
+
+
+class _Body(torch.nn.Module):
+    def __init__(self, item_tower: torch.nn.Module) -> None:
+        super().__init__()
+        self.item_tower = item_tower
+
+    def reset_parameters(self) -> None:
+        pass
+
+
+def _make_model(loss: torch.nn.Module) -> TwoTower:
+    return TwoTower(body=_Body(_ItemTower(cardinality=20, embedding_dim=8)), loss=loss)
+
+
+def _batch(seed: int, batch_size: int = 4) -> tuple[torch.Tensor, ...]:
+    generator = torch.Generator().manual_seed(seed)
+    embeddings = torch.randn(batch_size, 3, 8, generator=generator, requires_grad=True)
+    positives = torch.randint(0, 20, (batch_size, 3, 1), generator=generator)
+    negatives = torch.stack([torch.randperm(20, generator=generator)[:7] for _ in range(2)])
+    target_mask = torch.ones_like(positives, dtype=torch.bool)
+    padding_mask = torch.ones(batch_size, 3, dtype=torch.bool)
+    return embeddings, positives, negatives, padding_mask, target_mask
+
+
+def _loss(model: TwoTower, batch: tuple[torch.Tensor, ...]) -> torch.Tensor:
+    embeddings, positives, negatives, padding_mask, target_mask = batch
+    return model.loss(
+        model_embeddings=embeddings,
+        feature_tensors={},
+        positive_labels=positives,
+        negative_labels=negatives,
+        padding_mask=padding_mask,
+        target_padding_mask=target_mask,
+    )
+
+
+def test_grouped_loss_preserves_short_final_batch_weighting():
+    grouped_model = _make_model(GroupedCESampled(logical_batch_size=2, groups_per_batch=2))
+    short_batch = _batch(1, batch_size=1)
+    actual = _loss(grouped_model, short_batch)
+
+    embeddings, positives, negatives, _, target_mask = short_batch
+    active_embeddings = embeddings[target_mask.squeeze(-1)]
+    active_positives = positives.squeeze(-1)[target_mask.squeeze(-1)]
+    positive_logits = grouped_model.get_logits(active_embeddings, active_positives.unsqueeze(-1))
+    negative_logits = grouped_model.get_logits(active_embeddings, negatives[0])
+    negative_logits[active_positives.unsqueeze(-1) == negatives[0]] = -1e9
+    reference = (
+        torch.nn.functional.cross_entropy(
+            torch.cat((positive_logits, negative_logits), dim=-1),
+            torch.zeros(active_embeddings.size(0), dtype=torch.long),
+        )
+        / 2
+    )
+
+    torch.testing.assert_close(actual, reference)
+
+
+def test_catalog_cache_matches_uncached_loss_and_gradients():
+    uncached_model = _make_model(GroupedCESampled(logical_batch_size=2, groups_per_batch=2))
+    cached_model = _make_model(
+        CatalogCachedGroupedCESampled(
+            cardinality=20,
+            logical_batch_size=2,
+            groups_per_batch=2,
+            accumulation_steps=3,
+        )
+    )
+    cached_model.load_state_dict(copy.deepcopy(uncached_model.state_dict()))
+    uncached_batches = [_batch(seed) for seed in range(3)]
+    cached_batches = [
+        tuple(tensor.detach().clone().requires_grad_(tensor.requires_grad) for tensor in batch)
+        for batch in uncached_batches
+    ]
+
+    uncached_losses = []
+    for batch in uncached_batches:
+        loss = _loss(uncached_model, batch)
+        uncached_losses.append(loss.detach())
+        loss.backward()
+
+    cached_losses = []
+    for index, batch in enumerate(cached_batches):
+        is_window_end = index == 2
+        cached_model.loss.prepare_accumulation_microbatch(
+            is_window_end=is_window_end,
+            trainer_accumulation_steps=3,
+            global_step=0,
+        )
+        loss = _loss(cached_model, batch)
+        cached_losses.append(loss.detach())
+        loss.backward(retain_graph=cached_model.loss.should_retain_graph_for_current_backward())
+        cached_model.loss.assert_current_backward_completed()
+
+    cached_model.loss.assert_accumulation_cache_idle()
+    torch.testing.assert_close(torch.stack(cached_losses), torch.stack(uncached_losses))
+    torch.testing.assert_close(
+        cached_model.body.item_tower.weight.grad,
+        uncached_model.body.item_tower.weight.grad,
+    )
+    for cached_batch, uncached_batch in zip(cached_batches, uncached_batches, strict=True):
+        torch.testing.assert_close(cached_batch[0].grad, uncached_batch[0].grad)
+    assert cached_model.body.item_tower.forward_calls == 1
+    assert uncached_model.body.item_tower.forward_calls == 12
+    assert cached_model.state_dict().keys() == uncached_model.state_dict().keys()
+
+
+def test_catalog_cache_rejects_stochastic_item_tower():
+    loss = CatalogCachedGroupedCESampled(
+        cardinality=20,
+        logical_batch_size=2,
+        groups_per_batch=2,
+        accumulation_steps=2,
+    )
+    model = _make_model(loss)
+    model.body.item_tower.dropout = torch.nn.Dropout()
+    model.loss.prepare_accumulation_microbatch(
+        is_window_end=False,
+        trainer_accumulation_steps=2,
+        global_step=0,
+    )
+
+    with pytest.raises(TypeError, match="deterministic"):
+        _loss(model, _batch(0))
+
+
+def test_grouped_loss_validates_negative_pool_size():
+    model = _make_model(
+        GroupedCESampled(
+            logical_batch_size=2,
+            groups_per_batch=2,
+            expected_num_negatives=8,
+        )
+    )
+
+    with pytest.raises(ValueError, match="must contain 8"):
+        _loss(model, _batch(0))

--- a/tests/nn/transform/test_grouped_negative_sampling.py
+++ b/tests/nn/transform/test_grouped_negative_sampling.py
@@ -1,0 +1,40 @@
+import torch
+
+from replay.nn.transform import GroupedUniformNegativeSamplingTransform
+
+
+def _make_transform(generator: torch.Generator) -> GroupedUniformNegativeSamplingTransform:
+    return GroupedUniformNegativeSamplingTransform(
+        cardinality=100,
+        num_negative_samples=10,
+        group_size=2,
+        groups_per_batch=4,
+        generator=generator,
+    )
+
+
+def test_grouped_sampler_preserves_independent_random_pools():
+    grouped = _make_transform(torch.Generator().manual_seed(7))
+    reference = _make_transform(torch.Generator().manual_seed(7))
+
+    actual = grouped({"positive_labels": torch.zeros(8, 1, 1, dtype=torch.long)})["negative_labels"]
+    expected = torch.stack(
+        [reference({"positive_labels": torch.zeros(2, 1, 1, dtype=torch.long)})["negative_labels"][0] for _ in range(4)]
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_grouped_sampler_does_not_advance_rng_for_missing_final_groups():
+    grouped = _make_transform(torch.Generator().manual_seed(11))
+    reference = _make_transform(torch.Generator().manual_seed(11))
+
+    actual = grouped({"positive_labels": torch.zeros(3, 1, 1, dtype=torch.long)})["negative_labels"]
+    first_reference = reference({"positive_labels": torch.zeros(4, 1, 1, dtype=torch.long)})["negative_labels"]
+    next_actual = grouped({"positive_labels": torch.zeros(2, 1, 1, dtype=torch.long)})["negative_labels"][0]
+    next_reference = reference({"positive_labels": torch.zeros(2, 1, 1, dtype=torch.long)})["negative_labels"][0]
+
+    torch.testing.assert_close(actual[:2], first_reference[:2])
+    torch.testing.assert_close(actual[2], actual[1])
+    torch.testing.assert_close(actual[3], actual[1])
+    torch.testing.assert_close(next_actual, next_reference)


### PR DESCRIPTION
## Summary

Adds an opt-in TwoTower training path that uses a larger physical batch without
reducing how often independent negative pools are sampled.

The change consists of one coherent contract:

- `GroupedUniformNegativeSamplingTransform` draws one pool per logical group;
- `GroupedCESampled` applies each pool only to its group and preserves the
  weighting of a short final batch;
- a catalog-sized item-to-column lookup masks positive/negative collisions
  without materializing an additional target-by-negative boolean matrix;
- `CatalogCachedGroupedCESampled` builds one differentiable item catalog per
  gradient-accumulation window;
- `CatalogCacheLightningModule` supplies exact optimizer-window boundaries and
  verifies that no cached gradient crosses an epoch, validation or checkpoint
  boundary.

## Example

An original configuration used a physical batch of 128 on each of 2 GPUs and
12 accumulation steps: `128 × 2 × 12 = 3,072` rows per optimizer step. It also
sampled 12 independent negative pools per rank.

The packed configuration uses a physical batch of 512 containing four logical
groups of 128 and 3 accumulation steps: `512 × 2 × 3 = 3,072`. It still samples
`4 × 3 = 12` independent pools per rank. Thus the effective batch size and
negative-pool frequency are preserved while the query tower runs on larger
GPU-friendly tensors.

```python
sampler = GroupedUniformNegativeSamplingTransform(
    cardinality=num_items,
    num_negative_samples=40_000,
    group_size=128,
    groups_per_batch=4,
)
loss = CatalogCachedGroupedCESampled(
    cardinality=num_items,
    logical_batch_size=128,
    groups_per_batch=4,
    expected_num_negatives=40_000,
    accumulation_steps=3,
)
module = CatalogCacheLightningModule(model)
```

The cached loss accepts only the standard dot-product TwoTower head and rejects
stochastic or batch-dependent item towers. Its Lightning wrapper supports
automatic optimization with DDP-style strategies where Lightning controls
gradient accumulation. Unsupported lifecycle contracts fail before training.
The default TwoTower path is unchanged.

## Performance evidence

This mechanism was part of a production-like TwoTower run with 5,992,624
training rows, 5,001,267 validation rows, 6 epochs, FP32 and 2 NVIDIA A100
80 GiB GPUs. Together with target-aware trimming, length bucketing, deferred
metric synchronization and copy-free scoring, full job time changed from
7.064 to 3.487 hours (2.026x); controlled training throughput changed from
1,607.2 to 3,380.3 samples/s (2.103x).

Those numbers measure the complete optimization stack and are not attributed
to this PR alone. The combined stack increased peak allocated training memory
from 24.00 to 54.40 GiB per GPU and peak reserved memory from 47.29 to 59.17
GiB. The speed/memory trade-off is therefore explicit.

After six epochs, `unseen-recall@10` changed from 0.173549 to 0.171373
(-1.25%), while `coverage@100` changed from 0.967903 to 0.972298 (+0.45%).
This is one paired seed-777 run, not a statistical equivalence claim.
The measurements were collected in the downstream implementation that supplied
this port; the public branch has not been rerun as a six-epoch A100 job.

## Scope of the combined benchmark

The reusable code paths from that run are split across independent PRs:

- target-aware training trim: #98;
- length-bucketed query encoding: #99;
- one packed distributed metric reduction per epoch: #100;
- copy-free embedding tying: #101;
- grouped negative pools and the accumulation-window catalog cache: this PR.

Other settings from the run use existing library or Lightning interfaces and do
not require new RePlay code: validation batch size, skipped sanity validation,
weights-only checkpoints, CUDA allocator configuration, physical batch size and
gradient accumulation. Dataset transfer and pre-sharding remain pipeline-level
concerns rather than model-library behavior.

## Correctness validation

- cached and uncached grouped loss values match;
- query-tower and item-tower gradients match over three accumulated
  microbatches;
- the test item tower is evaluated once with the cache versus 12 times without
  it;
- independent RNG streams and missing final groups are covered;
- short final batches retain the original logical-batch weighting;
- ignored negative labels are replaced before item lookup;
- fast collision masking matches the generic sampled-CE result;
- a real `Trainer.fit` run covers three accumulated physical batches, the
  optimizer step, a short final batch and cache cleanup;
- stochastic item towers and invalid lifecycle transitions fail explicitly;
- state-dictionary keys are unchanged;
- 34 related loss, transform, Lightning and TwoTower tests passed;
- Ruff checks for the affected files and `git diff --check` passed.
